### PR TITLE
Backport sknorr's edits from the HPC relnotes to the docs

### DIFF
--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -194,7 +194,7 @@
      The Development Tools Module may provide later versions of the GNU
      compiler suite. Run
     </para>
-<screen>zypper search *-compilers-hpc</screen>
+<screen>zypper search '*-compilers-hpc'</screen>
     <para>
      to determine the available ones. If you have more than one version of
      the compiler suite installed, <emphasis>Lmod</emphasis> will pick the
@@ -223,11 +223,11 @@
    When these master packages are updated, the latest version of the
    respective packages will be installed while leaving previous versions
    installed. Library packages are split between runtime and compile time
-   packages. The compile time packages typically supply include files and
-   .so-files for shared libraries. Compile time package names end with
-   <literal>-devel</literal>. For some libraries static (<literal>.a</literal>)
-   libraries are supplied as well, package names for these end with
-   <literal>-devel-static</literal>.
+   packages. The compile time packages typically supply <literal>include</literal>
+   files and <literal>.so</literal> files for shared libraries. Compile time
+   package names end with <literal>-devel</literal>. For some libraries,
+   static (<literal>.a</literal>) libraries are supplied as well. Package names
+   for these end with <literal>-devel-static</literal>.
   </para>
   <para>
    As an example: Package names of the ScaLAPACK library version 2.0.2 built
@@ -280,10 +280,9 @@
   </para>
   <para>
    The Development Tools Module may provide later versions of the GNU
-   compiler suite. Run</para>
-   <screen>zypper search *-compilers-hpc</screen>
-   <para>to determine which ones are available.
+   compiler suite. To determine which ones are available, run:
   </para>
+<screen>zypper search '*-compilers-hpc'</screen>
   <sect2 xml:id="sec2-lib-boost">
    <title><literal>boost</literal> &mdash; Boost C++ Libraries</title>
    <para>

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -63,7 +63,7 @@
  /usr/share/lmod/lmod/init/zsh
  /usr/share/lmod/lmod/init/sh</screen>
    <para>
-    Pick the one appropriate for your shell. Then add the following to the
+    Pick the appropriate file for your shell. Then add the following to the
     init file of your shell:
    </para>
    <screen>source /usr/share/lmod/lmod/init/&lt;INIT-FILE&gt;</screen>
@@ -74,43 +74,44 @@
   <sect2 xml:id="sec2-compute-lmod-lista">
    <title>Listing available modules</title>
    <para>
-    To list the available all available modules, run: <command>module
-    spider</command>. To show all modules which can be loaded with the
-    currently loaded modules, run: <command>module avail</command>. A
-    module name consists of a name and a version string separated by a
+    To list all the available modules, run:
+    <command>module spider</command>.
+    To show all modules which can be loaded with the currently loaded modules,
+    run: 
+    <command>module avail</command>.
+    A module name consists of a name and a version string, separated by a
     <literal>/</literal> character. If more than one version is available
     for a certain module name, the default version (marked by
-    <literal>*</literal>) or (if this is not set) the one with the highest
-    version number is loaded. To refer to a specific module version, the
-    full string <literal><replaceable>NAME</replaceable>/<replaceable>VERSION</replaceable></literal>
-    may be used.
+    <literal>*</literal>). If there is no default, the one with the highest
+    version number is loaded. To reference a specific module version, you can
+    use the full string
+    <literal><replaceable>NAME</replaceable>/<replaceable>VERSION</replaceable></literal>.
    </para>
   </sect2>
   <sect2 xml:id="sec2-compute-lmod-listl">
    <title>Listing loaded modules</title>
    <para>
     <command>module list</command> shows all currently loaded modules. Refer
-    to <command>module help</command> for a short help on the module command
+    to <command>module help</command> for some short help on the module command,
     and <command>module help <replaceable>MODULE-NAME</replaceable></command>
-    for a help on the
-    particular module. Note that the <command>module</command> command is available
-    only when you log in after installing <literal>lua-lmod</literal>.
+    for help on the particular module.
+    The <command>module</command> command is only available when you log in
+    after installing <literal>lua-lmod</literal>.
    </para>
   </sect2>
   <sect2 xml:id="sec2-compute-lmod-info">
    <title>Gathering information about a module</title>
    <para>
-    To get information about a particular module, run: <command>module
-    whatis <replaceable>MODULE-NAME</replaceable></command> To load a module,
-    run:
-    <command>module load <replaceable>MODULE-NAME</replaceable></command>. This
-    will ensure
-    that your environment is modified (that is, the <literal>PATH</literal> and
-    <literal>LD_LIBRARY_PATH</literal> and other environment variables are
-    prepended) such that binaries and libraries provided by the respective
-    modules are found. To run a program compiled against this library, the
-    appropriate <command>module load</command> commands must be issued
-    beforehand.
+    To get information about a particular module, run:
+    <command>module whatis <replaceable>MODULE-NAME</replaceable></command>.
+    To load a module, run:
+    <command>module load <replaceable>MODULE-NAME</replaceable></command>.
+    This will ensure that your environment is modified (that is, the
+    <literal>PATH</literal> and <literal>LD_LIBRARY_PATH</literal> and other
+    environment variables are prepended), such that binaries and libraries
+    provided by the respective modules are found. To run a program compiled
+    against this library, the appropriate <command>module load</command>
+    commands must be issued beforehand.
    </para>
   </sect2>
   <sect2 xml:id="sec2-compute-lmod-load">
@@ -126,7 +127,7 @@
   <sect2 xml:id="sec2-compute-lmod-env">
    <title>Environment variables</title>
    <para>
-    If the respective development packages are installed, build time
+    If the respective development packages are installed, build-time
     environment variables like <literal>LIBRARY_PATH</literal>,
     <literal>CPATH</literal>, <literal>C_INCLUDE_PATH</literal> and
     <literal>CPLUS_INCLUDE_PATH</literal> will be set up to include the
@@ -167,9 +168,9 @@
    </para>
 <screen>zypper in gnu-compilers-hpc</screen>
    <para>
-    To set up the environment appropriately and select the GNU toolchain,
-    run, only then libraries built with the base compilers will become
-    available:
+    To make libraries built with the base compilers available, you need to set
+    up the environment appropriately and select the GNU toolchain.
+    To do so, run:
    </para>
 <screen>module load gnu</screen>
    </sect2>
@@ -192,19 +193,18 @@
     <title>Later versions</title>
     <para>
      The Development Tools Module may provide later versions of the GNU
-     compiler suite. Run
+     compiler suite. To determine the available compiler suites, run:
     </para>
 <screen>zypper search '*-compilers-hpc'</screen>
     <para>
-     to determine the available ones. If you have more than one version of
-     the compiler suite installed, <emphasis>Lmod</emphasis> will pick the
-     latest one by default. If you require an older version - or the base
-     version - append the version number:
+     If you have more than one version of the compiler suite installed,
+     <emphasis>Lmod</emphasis> will pick the latest one by default. If you
+     require an older version&mdash;or the base version&mdash;append the version
+     number:
     </para>
-    <screen>module load gnu/7</screen>
+<screen>module load gnu/7</screen>
     <para>
-     the version number of the compiler suite. For more information,
-     see <xref linkend="sec-compute-lmod"/>.
+     For more information, see: <xref linkend="sec-compute-lmod"/>.
     </para>
    </sect2>
  </sect1>
@@ -212,25 +212,25 @@
   <title>HPC libraries</title>
   <para>
    Library packages which support environment modules follow a distinctive
-   naming scheme: all packages have the compiler suite and, if built with
+   naming scheme: All packages have the compiler suite and, if built with
    MPI support, the MPI flavor included in their name:
-   <literal>*-[<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-]<replaceable>COMPILER</replaceable>-hpc*</literal>.
+   <literal>*-[<replaceable>MPI_FLAVOR</replaceable>-]<replaceable>COMPILER</replaceable>-hpc*</literal>.
    To facilitate the parallel installation of multiple versions of a library,
    the package name contains the version number (with dots
    <literal>.</literal> replaced by underscores <literal>_</literal>). To
-   simplify the installation of a library, 'master'-packages are supplied
-   which will ensure that the latest version of a package is installed.
-   When these master packages are updated, the latest version of the
-   respective packages will be installed while leaving previous versions
-   installed. Library packages are split between runtime and compile time
-   packages. The compile time packages typically supply <literal>include</literal>
-   files and <literal>.so</literal> files for shared libraries. Compile time
+   simplify the installation of a library, <literal>master-</literal> packages
+   are supplied which will ensure that the latest version of a package is
+   installed. When these master packages are updated, the latest version of the
+   respective packages will be installed, while leaving previous versions
+   installed. Library packages are split between runtime and compile-time
+   packages. The compile-time packages typically supply <literal>include</literal>
+   files and <literal>.so</literal> files for shared libraries. Compile-time
    package names end with <literal>-devel</literal>. For some libraries,
    static (<literal>.a</literal>) libraries are supplied as well. Package names
    for these end with <literal>-devel-static</literal>.
   </para>
   <para>
-   As an example: Package names of the ScaLAPACK library version 2.0.2 built
+   As an example, package names of the ScaLAPACK library version 2.0.2 built
    with GCC for Open MPI v2:
   </para>
   <itemizedlist>
@@ -265,22 +265,23 @@
    </listitem>
   </itemizedlist>
   <para>
-   (Note that the digit <literal>2</literal> appended to the library name
-   denotes the <literal>.so</literal> version of the library).
+   The digit <literal>2</literal> appended to the library name denotes the
+   <literal>.so</literal> version of the library.
   </para>
   <para>
-   To install a library packages run <command>zypper in
-   <replaceable>LIBRARY-MASTER-PACKAGE</replaceable></command>. To install a
-   development file,
-   run <command>zypper in <replaceable>LIBRARY-DEVEL-MASTER-PACKAGE</replaceable></command>.
+   To install a library package, run:
+   <command>zypper in <replaceable>LIBRARY-MASTER-PACKAGE</replaceable></command>.
+   To install a development file, run
+   <command>zypper in <replaceable>LIBRARY-DEVEL-MASTER-PACKAGE</replaceable></command>.
   </para>
   <para>
    Presently, the GNU compiler collection version 7 as provided with &shpca;
-   and the MPI flavors Open MPI v.3 and v.4 as well as MPICH and MVAPICH2 are supported.
+   and the MPI flavors Open MPI v.3 and v.4 as well as MPICH and MVAPICH2 are
+   supported.
   </para>
   <para>
    The Development Tools Module may provide later versions of the GNU
-   compiler suite. To determine which ones are available, run:
+   compiler suite. To view available compilers, run:
   </para>
 <screen>zypper search '*-compilers-hpc'</screen>
   <sect2 xml:id="sec2-lib-boost">
@@ -294,11 +295,11 @@
    <para>
     To load the highest available serial version of this module, run:
    </para>
-   <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> boost</screen>
+   <screen>module load <replaceable>TOOLCHAIN</replaceable> boost</screen>
    <para>
      or
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> boost</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> boost</screen>
    <para>
     if MPI specific boost libraries are to be used.
    </para>
@@ -331,18 +332,18 @@
    </para>
    <itemizedlist>
     <listitem><para>
-      <package>boost-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>boost-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para></listitem>
     <listitem><para>
-      <package>boost-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</package>
+      <package>boost-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</package>
      </para></listitem>
     <listitem><para>
-      <package>boost-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-python3</package>
+      <package>boost-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-python3</package>
      </para></listitem>
    </itemizedlist>
    <para>
-    <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> is one of the supported
-    MPI flavors <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
+    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
   <sect2 xml:id="sec2-lib-fftw">
@@ -359,11 +360,11 @@
     MPI variant, the respective MPI module needs to be loaded beforehand. To
     load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> fftw3</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> fftw3</screen>
    <para>
      or
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> fftw3</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> fftw3</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
     information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
@@ -384,18 +385,18 @@
     </listitem>
     <listitem>
      <para>
-      <literal>libfftw3-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>libfftw3-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>fftw3-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</literal>
+      <literal>fftw3-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> is one of the supported
-    MPI flavors <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
+    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
 
@@ -416,7 +417,7 @@
    </para>
    <para>
     There are also basic facilities for discrete Fourier transform, basic
-    linear algebra and random number generation.
+    linear algebra, and random number generation.
    </para>
    <para>
     This package is available both for Python 2 and 3. The specific
@@ -425,7 +426,7 @@
     to be specified when loading this module. To load this module,
     run:
    </para>
-    <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> python<replaceable>&lt;PYTHON_VERSION&gt;</replaceable>-numpy</screen>
+    <screen>module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-numpy</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
    </para>
@@ -435,12 +436,12 @@
    <itemizedlist>
     <listitem>
      <para>
-      <literal>python<replaceable>&lt;PYTHON_VERSION&gt;</replaceable>-numpy-gnu-hpc</literal>
+      <literal>python<replaceable>PYTHON_VERSION</replaceable>-numpy-gnu-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>python<replaceable>&lt;PYTHON_VERSION&gt;</replaceable>-numpy-gnu-hpc-devel</literal>
+      <literal>python<replaceable>PYTHON_VERSION</replaceable>-numpy-gnu-hpc-devel</literal>
      </para>
     </listitem>
    </itemizedlist>
@@ -471,7 +472,7 @@
     library. The correct library module for the Python version used needs
     to be specified when loading this module. To load this module, run:
    </para>
-    <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> python<replaceable>&lt;PYTHON_VERSION&gt;</replaceable>-scipy</screen>
+    <screen>module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-scipy</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
    </para>
@@ -481,12 +482,12 @@
    <itemizedlist>
     <listitem>
      <para>
-      <literal>python<replaceable>&lt;PYTHON_VERSION&gt;</replaceable>-scipy-gnu-hpc</literal>
+      <literal>python<replaceable>PYTHON_VERSION</replaceable>-scipy-gnu-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>python<replaceable>&lt;PYTHON_VERSION&gt;</replaceable>-scipy-gnu-hpc-devel</literal>
+      <literal>python<replaceable>PYTHON_VERSION</replaceable>-scipy-gnu-hpc-devel</literal>
      </para>
     </listitem>
    </itemizedlist>
@@ -496,26 +497,26 @@
    <!-- href="https://fate.novell.com/324153" -->
    <title>HYPRE &mdash; scalable linear solvers and multigrid methods</title>
    <para>
-    HYPRE is a library of linear solvers which aim to solve large
-    and detailed simulations faster than traditional methods at
-    large scales.
+    HYPRE is a library of linear solvers which aim to solve large and detailed
+    simulations faster than traditional methods at large scales.
    </para>
    <para>
-    The library offers a comprehensive suite of
-    scalable solvers for large-scale scientific simulation,
-    featuring parallel multigrid methods for both structured
-    and unstructured grid problems. HYPRE is highly portable
-    and supports a number of languages, and is developed at
-    Lawrence Livermore National Laboratory.
+    The library offers a comprehensive suite of scalable solvers for large-scale
+    scientific simulation, featuring parallel multigrid methods for both
+    structured and unstructured grid problems. HYPRE is highly portable, and
+    supports a number of languages, and is developed at Lawrence Livermore
+    National Laboratory.
    </para>
    <para>
-    For this library a compiler toolchain and an MPI flavor
-    needs to be loaded beforehand. To load this, run:
+    For this library, a compiler toolchain and an MPI flavor
+    needs to be loaded beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> hypre</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> hypre</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -523,12 +524,12 @@
    <itemizedlist>
     <listitem>
      <para>
-      <literal>hypre-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</literal>
+      <literal>hypre-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>libHYPRE-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>libHYPRE-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
    </itemizedlist>
@@ -569,7 +570,7 @@
     For this library a compiler toolchain needs to be loaded
     beforehand. To load metis, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> metis</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> metis</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
    </para>
@@ -624,7 +625,7 @@
     For this library a compiler toolchain needs to be loaded
     beforehand. To load gsl, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> gsl</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> gsl</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
    </para>
@@ -678,11 +679,11 @@
     For this library a compiler toolchain and if applicable, an MPI
     flavor needs to be loaded beforehand. To load ocr, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> ocr</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> ocr</screen>
    <para>
      or
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> ocr</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> ocr</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
     information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
@@ -713,22 +714,22 @@
     </listitem>
     <listitem>
      <para>
-      <literal>ocr-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>ocr-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>ocr-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</literal>
+      <literal>ocr-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>ocr-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-doc</literal>
+      <literal>ocr-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-doc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>ocr-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-examples</literal>
+      <literal>ocr-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-examples</literal>
      </para>
     </listitem>
    </itemizedlist>
@@ -782,12 +783,14 @@
    </para>
    <para>
     This library requires a compiler toolchain and an MPI flavor
-    to be loaded beforehand. To load this, run:
+    to be loaded beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> mumps</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> mumps</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -795,22 +798,22 @@
    <itemizedlist>
     <listitem>
      <para>
-      <literal>libmumps-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>libmumps-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>mumps-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</literal>
+      <literal>mumps-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>mumps-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-doc</literal>
+      <literal>mumps-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-doc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>mumps-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-examples</literal>
+      <literal>mumps-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-examples</literal>
      </para>
     </listitem>
    </itemizedlist>
@@ -887,20 +890,20 @@
      <para>
       standard version:
      </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> openblas</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> openblas</screen>
     </listitem>
     <listitem>
      <para>
       OpenMP/pthreads version:
      </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> openblas-pthreads</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> openblas-pthreads</screen>
     </listitem>
    </itemizedlist>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
    </para>
    <para>
-    List of master package for:
+    List of master packages:
    </para>
    <itemizedlist>
     <listitem>
@@ -937,7 +940,7 @@
     This module requires loading a compiler toolchain as well as an MPI
     library flavor beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> petsc</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> petsc</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
     information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
@@ -948,32 +951,33 @@
    <itemizedlist>
     <listitem>
      <para>
-      <literal>libpetsc-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>libpetsc-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>petsc-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</literal>
+      <literal>petsc-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> is one of the supported
-    MPI flavors <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
+    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
   <sect2 xml:id="sec2-lib-scal">
    <!-- href="https://fate.novell.com/321715" -->
    <title>ScaLAPACK HPC library &mdash; LAPACK routines</title>
    <para>
-    The library ScaLAPACK (short for "Scalable LAPACK") includes a subset of
-    LAPACK routines designed for distributed memory MIMD-parallel computers.
+    The library ScaLAPACK (short for <emphasis>Scalable LAPACK</emphasis>)
+    includes a subset of LAPACK routines designed for distributed memory
+    MIMD-parallel computers.
    </para>
    <para>
     This library requires loading both a compiler toolchain and an MPI
-    library flavor beforehand. To load this library, run:
+    library flavor beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> scalapack</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> scalapack</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
     information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
@@ -984,18 +988,18 @@
    <itemizedlist>
     <listitem>
      <para>
-      <literal>libscalapack2-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>libscalapack2-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>libscalapack2-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</literal>
+      <literal>libscalapack2-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> is one of the supported
-    MPI flavors <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
+    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
   <sect2 xml:id="sec2-lib-scotch">
@@ -1015,12 +1019,14 @@
    </para>
    <para>
     For this library a compiler toolchain and an MPI flavor
-    needs to be loaded beforehand. To load this, run:
+    needs to be loaded beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> scotch</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> scotch</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1028,17 +1034,17 @@
    <itemizedlist>
     <listitem>
      <para>
-      <literal>libptscotch-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>libptscotch-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>ptscotch-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>ptscotch-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
         <listitem>
      <para>
-      <literal>ptscotch-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</literal>
+      <literal>ptscotch-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
    </itemizedlist>
@@ -1049,16 +1055,22 @@
    <para>
     SuperLU is a general purpose library for the direct solution of large,
     sparse, nonsymmetric systems of linear equations. The library is written
-    in C and is callable from either C or Fortran program.
+    in C and can be called from C and Fortran programs.
    </para>
+<!-- Possible fixmes in the following para:
+    * 5-word compound noun: "Working precision iterative refinement subroutines"
+    * Can "preordering" be replaced by "sorting" or something similarly unambiguous?
+    * "equilibrate" seems unnecessarily complicated
+    - sknorr, 2020-12-17
+-->
    <para>
-    It uses MPI, OpenMP to support various forms of parallelism. It supports
+    It uses MPI and OpenMP to support various forms of parallelism. It supports
     both real and complex data types, both single and double precision, and
     64-bit integer indexing. The library routines performs an LU decomposition
     with partial pivoting and triangular system solves through forward and
     back substitution. The LU factorization routines can handle non-square
-    matrices but the triangular solves are performed only for square matrices.
-    The matrix columns may be preordered (before factorization) either through
+    matrices, but the triangular solves are performed only for square matrices.
+    The matrix columns can be preordered (before factorization) either through
     library or user supplied routines. This preordering for sparsity is
     completely separate from the factorization. Working precision iterative
     refinement subroutines are provided for improved backward stability.
@@ -1068,9 +1080,9 @@
    </para>
    <para>
     This library requires a compiler toolchain and an MPI flavor
-    to be loaded beforehand. To load this, run:
+    to be loaded beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> superlu</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> superlu</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
    </para>
@@ -1112,12 +1124,14 @@
    </para>
    <para>
     This library needs a compiler toolchain and and MPI flavor
-    to be loaded beforehand. To load this, run:
+    to be loaded beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> trilinos</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> trilinos</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1125,12 +1139,12 @@
    <itemizedlist>
     <listitem>
      <para>
-      <literal>libtrilinos-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>libtrilinos-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>trilinos-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</literal>
+      <literal>trilinos-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
    </itemizedlist>
@@ -1147,10 +1161,12 @@
     information, see
     <link xlink:href="https://www.olcf.ornl.gov/center-projects/adios/"/>.
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> adios</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> adios</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1158,18 +1174,18 @@
    <itemizedlist>
     <listitem>
      <para>
-      <package>adios-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>adios-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para>
     </listitem>
     <listitem>
      <para>
-      <package>adios-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</package>
+      <package>adios-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</package>
      </para>
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> is one of the supported
-    MPI flavors <xref linkend="sec1-MPI-libs"/>.
+    Replace <replaceable>MPI_FLAVOR</replaceable> with one of the supported
+    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
   <sect2 xml:id="sec2-lib-hdf5">
@@ -1188,17 +1204,19 @@
     also require loading the correct MPI flavor module.
    </para>
    <para>
-    To load the highest available serial version of this module run:
+    To load the highest available serial version of this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> hdf5</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> hdf5</screen>
    <para>
     When an MPI flavor is loaded, the MPI version of this module can be
     loaded by:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> phpdf5</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> phpdf5</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1241,28 +1259,28 @@
     </listitem>
     <listitem>
      <para>
-      <package>hdf5-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</package>
+      <package>hdf5-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</package>
      </para>
     </listitem>
     <listitem>
      <para>
-      <package>libhdf5-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>libhdf5-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para>
     </listitem>
     <listitem>
      <para>
-      <package>libhdf5_fortran-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>libhdf5_fortran-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para>
     </listitem>
     <listitem>
      <para>
-      <package>libhdf5_hl_fortran-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>libhdf5_hl_fortran-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para>
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> is one of the supported
-    MPI flavors <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
+    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     For general information about Lmod and modules, see
@@ -1295,10 +1313,12 @@
     load the highest version of the non-MPI <literal>netcdf</literal> module,
     run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> netcdf</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> netcdf</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>,
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1326,23 +1346,23 @@
     </listitem>
     <listitem>
      <para>
-      <package>netcdf-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>netcdf-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para>
     </listitem>
     <listitem>
      <para>
-      <package>netcdf-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</package>
+      <package>netcdf-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</package>
      </para>
     </listitem>
     <listitem>
      <para>
-      <package>netcdf-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>netcdf-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para>
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> is one of the supported
-    MPI flavors <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
+    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
    <bridgehead renderas="sect5"><literal>netcdf-cxx</literal> Packages</bridgehead>
    <para>
@@ -1353,9 +1373,10 @@
     This module requires loading a compiler toolchain module beforehand. To
     load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> netcdf-cxx4</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> netcdf-cxx4</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -1393,14 +1414,16 @@
     load the highest version of the non-MPI <literal>netcdf-fortran</literal> module,
     run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> netcdf-fortran</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> netcdf-fortran</screen>
    <para>
     or
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> netcdf-fortran</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> netcdf-fortran</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>,
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1423,17 +1446,17 @@
     </listitem>
     <listitem>
      <para>
-      <literal>libnetcdf-fortran-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>libnetcdf-fortran-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>libnetcdf-fortran-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</literal>
+      <literal>libnetcdf-fortran-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>libnetcdf-fortran-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>libnetcdf-fortran-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
    </itemizedlist>
@@ -1454,30 +1477,32 @@
    The package is available for the MPI Flavors: Open MPI 2 and 3, MVAPICH2 and MPICH.
    </para>
    <para>
-    To load the highest available serial version of this module run:
+    To load the highest available serial version of this module, run:
    </para>
-   <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> pnetcdf</screen>
+   <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> pnetcdf</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of MPI master packages:
    </para>
    <itemizedlist>
     <listitem><para>
-      <package>libpnetcdf-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>libpnetcdf-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para></listitem>
     <listitem><para>
-      <package>pnetcdf-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>pnetcdf-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para></listitem>
     <listitem><para>
-      <package>pnetcdf-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</package>
+      <package>pnetcdf-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</package>
      </para></listitem>
    </itemizedlist>
    <para>
-    <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> is one of the supported
-    MPI flavors <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
+    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
  </sect1>
@@ -1576,25 +1601,25 @@
     <para>
      For Open MPI v.3:
     </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> openmpi/3</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> openmpi/3</screen>
    </listitem>
    <listitem>
     <para>
      For Open MPI v.4:
     </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> openmpi/4</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> openmpi/4</screen>
    </listitem>
    <listitem>
     <para>
      For MVAPICH2:
     </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> mvapich2</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> mvapich2</screen>
    </listitem>
    <listitem>
     <para>
       For MPICH:
     </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> mpich</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> mpich</screen>
    </listitem>
   </itemizedlist>
    <para>
@@ -1624,17 +1649,19 @@
    </para>
       <para>
     For the IMB binaries to be found, a compiler toolchain and an MPI flavor
-    need to be loaded beforehand. To load this, run:
+    need to be loaded beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> imb</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> imb</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <itemizedlist>
     <listitem>
      <para>
-      <literal>imb-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</literal>
+      <literal>imb-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
    </itemizedlist>
@@ -1648,13 +1675,14 @@
     hardware found in most major microprocessors.
    </para>
    <para>
-    This package serves all compiler toolchains and does not require a
+    This package works with all compiler toolchains and does not require a
     compiler toolchain to be selected. The latest version provided can be
-    selected by running:
+    loaded by running:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> papi</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> papi</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -1691,12 +1719,14 @@
    </para>
    <para>
     For this library a compiler toolchain and and MPI flavor
-    needs to be loaded beforehand. To load this, run:
+    needs to be loaded beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> mpip</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> mpip</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, see:
+    <xref linkend="sec-compiler"/>.
+    For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1704,23 +1734,23 @@
    <itemizedlist>
     <listitem>
      <para>
-      <package>mpiP-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc</package>
+      <package>mpiP-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
      </para>
     </listitem>
     <listitem>
      <para>
-      <package>mpiP-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-devel</package>
+      <package>mpiP-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</package>
      </para>
     </listitem>
     <listitem>
      <para>
-      <literal>mpiP-gnu-<replaceable>&lt;MPI_FLAVOR&gt;</replaceable>-hpc-doc</literal>
+      <literal>mpiP-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-doc</literal>
      </para>
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> is one of the supported
-    MPI flavors <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
+    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
  </sect1>

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -178,8 +178,8 @@
     <para>
      To use the GNU compiler collection to build your own libraries and
      applications, <package>gnu-compilers-hpc-devel</package> needs to be
-     installed. It makes sure all compiler components required for HPC (ie.
-     C, C++ and Fortran Compliers) are installed.
+     installed. It makes sure all compiler components required for HPC (that is,
+     C, C++ and Fortran Compilers) are installed.
     </para>
     <para>
      The environment variables <literal>CC</literal>, <literal>CXX</literal>,
@@ -304,7 +304,7 @@
    </para>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -366,7 +366,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> fftw3</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -515,7 +515,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> hypre</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -685,7 +685,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> ocr</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -787,7 +787,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> mumps</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -940,7 +940,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> petsc</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -976,7 +976,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> scalapack</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1020,7 +1020,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> scotch</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1053,7 +1053,7 @@
    </para>
    <para>
     It uses MPI, OpenMP to support various forms of parallelism. It supports
-    both real and complex datatypes, both single and double precision, and
+    both real and complex data types, both single and double precision, and
     64-bit integer indexing. The library routines performs an LU decomposition
     with partial pivoting and triangular system solves through forward and
     back substitution. The LU factorization routines can handle non-square
@@ -1117,7 +1117,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> trilinos</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1150,7 +1150,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> adios</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1198,7 +1198,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> phpdf5</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1298,7 +1298,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> netcdf</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1400,7 +1400,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> netcdf-fortran</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1459,7 +1459,7 @@
    <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> pnetcdf</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of MPI master packages:
@@ -1606,7 +1606,7 @@
   <title>Profiling and benchmarking libraries and tools</title>
   <para>
    Performance optimization plays an important role in HPC. That applications
-   are run across multiple cluster nodes poses an additional challange.
+   are run across multiple cluster nodes poses an additional challenge.
    &shpca; provides a number of tools for profiling MPI applications and
    benchmarking MPI performance.
   </para>
@@ -1629,7 +1629,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> imb</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <itemizedlist>
     <listitem>
@@ -1696,7 +1696,7 @@
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> mpip</screen>
    <para>
     For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on avaiable MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -1613,19 +1613,19 @@
   </para>
   <sect2 xml:id="sec2-tool-imb">
    <!-- href="https://fate.novell.com/324155" -->
-   <title>IMB &mdash; Intel&thrdmrk; MPI benchmarks</title>
+   <title>IMB &mdash; Intel* MPI benchmarks</title>
    <para>
-    Intel(R) MPI Benchmarks provides a set of elementary benchmarks that conform
-    to MPI-1, MPI-2, and MPI-3 standard. One can run all of the supported
-    benchmarks, or a subset specified in the command line using one executable
+    Intel* MPI Benchmarks provides a set of elementary benchmarks that conform
+    to the MPI-1, MPI-2, and MPI-3 standards. One can run all of the supported
+    benchmarks, or a subset specified in the command line, using one executable
     file. Use command-line parameters to specify various settings, such as time
     measurement, message lengths, and selection of communicators. For details, see
-    the Intel(R) MPI Benchmarks User's Guide located at:
-    https://software.intel.com/en-us/imb-user-guide.
+    the Intel* MPI Benchmarks User's Guide located at:
+    <link xlink:href="https://software.intel.com/en-us/imb-user-guide"/>.
    </para>
       <para>
     For the IMB binaries to be found, a compiler toolchain and an MPI flavor
-    needs to be loaded beforehand. To load this, run:
+    need to be loaded beforehand. To load this, run:
    </para>
 <screen>module load <replaceable>&lt;TOOLCHAIN&gt;</replaceable> <replaceable>&lt;MPI_FLAVOR&gt;</replaceable> imb</screen>
    <para>

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -180,7 +180,7 @@
      To use the GNU compiler collection to build your own libraries and
      applications, <package>gnu-compilers-hpc-devel</package> needs to be
      installed. It makes sure all compiler components required for HPC (that is,
-     C, C++ and Fortran Compilers) are installed.
+     C, C++, and Fortran compilers) are installed.
     </para>
     <para>
      The environment variables <literal>CC</literal>, <literal>CXX</literal>,
@@ -503,8 +503,8 @@
    <para>
     The library offers a comprehensive suite of scalable solvers for large-scale
     scientific simulation, featuring parallel multigrid methods for both
-    structured and unstructured grid problems. HYPRE is highly portable, and
-    supports a number of languages, and is developed at Lawrence Livermore
+    structured and unstructured grid problems. HYPRE is highly portable and
+    supports a number of languages. It is developed at Lawrence Livermore
     National Laboratory.
    </para>
    <para>
@@ -1291,7 +1291,7 @@
    <!-- href="https://fate.novell.com/321719" -->
    <title>NetCDF HPC library &mdash; implementation of self-describing data formats</title>
    <para>
-    The NetCDF software libraries for C, C++, FORTRAN, and Perl are a set of
+    The NetCDF software libraries for C, C++, Fortran, and Perl are a set of
     software libraries and self-describing, machine-independent data formats
     that support the creation, access, and sharing of array-oriented
     scientific data.
@@ -1400,7 +1400,7 @@
    </itemizedlist>
    <bridgehead renderas="sect5"><literal>netcdf-fortran</literal> Packages</bridgehead>
    <para>
-    The <literal>netcdf-fortran</literal> packages provide FORTRAN bindings
+    The <literal>netcdf-fortran</literal> packages provide Fortran bindings
     for the NetCDF API, with and without MPI support.
    </para>
    <para>
@@ -1637,14 +1637,15 @@
   </para>
   <sect2 xml:id="sec2-tool-imb">
    <!-- href="https://fate.novell.com/324155" -->
-   <title>IMB &mdash; Intel* MPI benchmarks</title>
+   <title>IMB &mdash; Intel&thrdmrk; MPI benchmarks</title>
    <para>
-    Intel* MPI Benchmarks provides a set of elementary benchmarks that conform
-    to the MPI-1, MPI-2, and MPI-3 standards. One can run all of the supported
-    benchmarks, or a subset specified in the command line, using one executable
-    file. Use command-line parameters to specify various settings, such as time
-    measurement, message lengths, and selection of communicators. For details, see
-    the Intel* MPI Benchmarks User's Guide located at:
+    The Intel&thrdmrk; MPI Benchmarks package provides a set of elementary
+    benchmarks that conform to the MPI-1, MPI-2, and MPI-3 standards. You can
+    run all of the supported benchmarks, or a subset specified in the command
+    line, using a single executable file. Use command-line parameters to specify
+    various settings, such as time measurement, message lengths, and selection
+    of communicators. For details, see the Intel&thrdmrk; MPI Benchmarks User's
+    Guide located at:
     <link xlink:href="https://software.intel.com/en-us/imb-user-guide"/>.
    </para>
       <para>

--- a/xml/hardware.xml
+++ b/xml/hardware.xml
@@ -16,7 +16,7 @@
  <info>
   <abstract>
    <para>
-    Here tools are described which may be used to obtain information
+    This chapter describes tools which can be used to obtain information
     about the hardware infrastucture of components of interest for HPC
     applications.
    </para>

--- a/xml/hardware.xml
+++ b/xml/hardware.xml
@@ -16,7 +16,7 @@
  <info>
   <abstract>
    <para>
-    Here tools are describes which may be used to obtain information
+    Here tools are described which may be used to obtain information
     about the hardware infrastucture of components of interest for HPC
     applications.
    </para>
@@ -31,15 +31,14 @@
   <para>
    <literal>cpuid</literal> executes the x86 CPUID instruction and decodes
    and prints the results to stdout. Its knowledge of Intel, AMD and Cyrix
-   CPUs is fairly complete. It specifically targets the Intel XeonPhi
+   CPUs is fairly complete. It specifically targets the Intel Xeon Phi
    architecture.
   </para>
   <para>
-   To install <literal>cpuid</literal>, run: <literal>zypper in
-   cpuid</literal>.
+   To install <command>cpuid</command>, run: <literal>zypper in cpuid</literal>.
   </para>
   <para>
-   For information about runtime options for <literal>cpuid</literal>, see the
+   For information about runtime options for <command>cpuid</command>, see the
    man page <literal>cpuid(1)</literal>.
   </para>
   <para>
@@ -50,16 +49,17 @@
   <title>hwloc &mdash; portable abstraction of hierarchical architectures for high-performance computing</title>
   <para>
    <literal>hwloc</literal> provides CLI tools and a C API to
-   obtain the hierarchical map of key computing elements, such as: NUMA
+   obtain the hierarchical map of key computing elements, such as NUMA
    memory nodes, shared caches, processor packages, processor cores,
-   processing units (logical processors or "threads") and even I/O devices.
-   <literal>hwloc</literal> also gathers various attributes such as cache
-   and memory information, and is portable across a variety of different
-   operating systems and platforms. Additionally it may assemble the
-   topologies of multiple machines into a single one, to let
-   applications consult the topology of an entire fabric or cluster at
-   once.
+   processing units (logical processors or <quote>threads</quote>) and even I/O
+   devices. <literal>hwloc</literal> also gathers various attributes such as
+   cache and memory information, and is portable across a variety of different
+   operating systems and platforms. Additionally it can assemble the
+   topologies of multiple machines into a single one, to let applications
+   consult the topology of an entire fabric or cluster at once.
   </para>
+  <!-- "consult" above sounds like the wrong word. - sknorr, 2020-12-16 -->
+  
   <para>
    <emphasis>lstopo</emphasis> allows the user to obtain the topology
    of a machine or convert topology information obtained on a remote

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -51,7 +51,7 @@
       <itemizedlist>
        <listitem>
         <para>
-         Uses BTRFS as the default root file system
+         Uses Btrfs as the default root file system
         </para>
        </listitem>
        <listitem>
@@ -61,12 +61,12 @@
        </listitem>
        <listitem>
         <para>
-         Disables firewall and Kdump services
+         Disables the firewall and kdump services
         </para>
        </listitem>
        <listitem>
         <para>
-         Installs controller for the Slurm Workload Manager
+         Installs a controller for the Slurm Workload Manager
         </para>
        </listitem>
        <listitem>
@@ -96,17 +96,17 @@
        </listitem>
        <listitem>
         <para>
-         Disables firewall and Kdump services
+         Disables firewall and kdump services
         </para>
        </listitem>
        <listitem>
         <para>
-         Based from minimal setup configuration
+         Based upon the minimal setup configuration
         </para>
        </listitem>
        <listitem>
         <para>
-         Installs client for the Slurm Workload Manager
+         Installs a client for the Slurm workload manager
         </para>
        </listitem>
        <listitem>
@@ -136,7 +136,7 @@
        </listitem>
        <listitem>
         <para>
-         Adds compilers and development toolchain
+         Adds compilers and development toolchains
         </para>
        </listitem>
       </itemizedlist>
@@ -146,22 +146,22 @@
    <para>
     The scratch partition <literal>/var/tmp/</literal> will only be created if
     there is sufficient space available on the installation medium (minimum
-    32 GB).
+    32&nbsp;GB).
    </para>
    <para>
     The Environment Module <literal>Lmod</literal> will be installed for all
     roles. It is required at build time and run time of the system.
    </para>
    <para>
-    All libraries specifically build for HPC will be installed under
+    All libraries specifically built for HPC will be installed under
     <literal>/usr/lib/hpc</literal>. They are not part of the standard search
     path, thus the <literal>Lmod</literal> environment module system is
     required.
    </para>
    <para>
-    <literal>Munge</literal> authentication is installed for all roles. This
-    requires to copy the same generated munge keys to all nodes of a cluster.
-    For more information, see <xref linkend="sec-remote-munge"/>.
+    <literal>Munge</literal> authentication is installed for all roles. Munge
+    keys will be generated and the same keys must be copied to all nodes of a
+    cluster. For more information, see <xref linkend="sec-remote-munge"/>.
    </para>
    <para>
     From the Ganglia monitoring system, the data collector

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -61,12 +61,12 @@
        </listitem>
        <listitem>
         <para>
-         Disables the firewall and kdump services
+         Disables the firewall and Kdump services
         </para>
        </listitem>
        <listitem>
         <para>
-         Installs a controller for the Slurm Workload Manager
+         Installs a controller for the Slurm workload manager
         </para>
        </listitem>
        <listitem>
@@ -159,7 +159,7 @@
     required.
    </para>
    <para>
-    <literal>Munge</literal> authentication is installed for all roles. Munge
+    <literal>MUNGE</literal> authentication is installed for all roles. MUNGE
     keys will be generated and the same keys must be copied to all nodes of a
     cluster. For more information, see <xref linkend="sec-remote-munge"/>.
    </para>

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -206,7 +206,7 @@
     (<literal>x86_64</literal>, <literal>aarch64</literal>).
     #else
     -->
-    You can upgrade to &shpca; &this-version; from &shpca;_&prev-version;.
+    You can upgrade to &shpca; &this-version; from &shpca; &prev-version;.
  <!-- #endif -->
    </para>
   </sect2>

--- a/xml/introduction.xml
+++ b/xml/introduction.xml
@@ -32,7 +32,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     Workload manager
+     A workload manager
     </para>
    </listitem>
    <listitem>
@@ -47,12 +47,12 @@
    </listitem>
    <listitem>
     <para>
-     Serial console monitoring tool
+     A serial-console monitoring tool
     </para>
    </listitem>
    <listitem>
     <para>
-     Cluster power management tool
+     A cluster power management tool
     </para>
    </listitem>
    <listitem>
@@ -77,8 +77,8 @@
    </listitem>
    <listitem>
     <para>
-     User-extensible heap manager capable of distinguishing between different kinds
-     of memory (x86-64 only)
+     A user-extensible heap manager capable of distinguishing between different
+     kinds of memory (x86-64 only)
     </para>
    </listitem>
    <listitem>
@@ -88,8 +88,8 @@
    </listitem>
    <listitem>
     <para>
-     Serial and parallel computational libraries providing the common standards
-     BLAS, LAPACK, ...
+     Serial and parallel computational libraries providing many common
+     standards, such as BLAS, LAPACK, and many others.
     </para>
    </listitem>
    <listitem>
@@ -110,7 +110,7 @@
   <title>Support and life cycle</title>
   <para>
    &product; &this-version; is supported throughout the life cycle of
-   &slea; &this-version;. Two live-cycle extensions, 'Extended Service
+   &slea; &this-version;. Two life-cycle extensions, 'Extended Service
    Overlap Support' (ESPOS) and 'Long Term Support Service' (LTSS), are also
    available for this product. Any released package is fully maintained
    and supported until the availability of the next release.

--- a/xml/introduction.xml
+++ b/xml/introduction.xml
@@ -23,7 +23,7 @@
   </abstract>
  </info>
  <sect1 xml:id="sec-intro-provides">
-  <title>Provides</title>
+  <title>Components provided</title>
   <para>
    &product; &this-version; provides tools and libraries related to
    High-Performance Computing.
@@ -88,8 +88,8 @@
    </listitem>
    <listitem>
     <para>
-     Serial and parallel computational libraries providing many common
-     standards, such as BLAS, LAPACK, and many others.
+     Serial and parallel computational libraries providing common standards,
+     such as BLAS, LAPACK, and many others.
     </para>
    </listitem>
    <listitem>
@@ -110,10 +110,11 @@
   <title>Support and life cycle</title>
   <para>
    &product; &this-version; is supported throughout the life cycle of
-   &slea; &this-version;. Two life-cycle extensions, 'Extended Service
-   Overlap Support' (ESPOS) and 'Long Term Support Service' (LTSS), are also
-   available for this product. Any released package is fully maintained
-   and supported until the availability of the next release.
+   &slea; &this-version;. Two life-cycle extensions, <emphasis>Extended Service
+   Overlap Support</emphasis> (ESPOS) and <emphasis>Long Term Support
+   Service</emphasis> (LTSS), are also available for this product. Any released
+   package is fully maintained and supported until the availability of the next
+   release.
   </para>
   <para>
    For more information, see the Support Policy page

--- a/xml/monitoring.xml
+++ b/xml/monitoring.xml
@@ -177,7 +177,7 @@
   <para>
    To check whether the EDAC drivers are loaded, execute:
   </para>
-  <screen>ras-mc-ctl --status</screen>
+<screen>ras-mc-ctl --status</screen>
   <para>
    The command should return <literal>ras-mc-ctl: drivers are
    loaded</literal>. If it indicates that the drivers are not loaded, EDAC
@@ -192,11 +192,11 @@
    <filename>/var/log/messages</filename> and to an internal database. A
    summary of the stored errors can be obtained with:
   </para>
-  <screen>ras-mc-ctl --summary</screen>
+<screen>ras-mc-ctl --summary</screen>
   <para>
-   The errors stored in the database can be viewed with
+   The errors stored in the database can be viewed with:
   </para>
-  <screen>ras-mc-ctl --errors</screen>
+<screen>ras-mc-ctl --errors</screen>
   <para>
    Optionally, you can load the DIMM labels silk-screened on the system
    board to more easily identify the faulty DIMM. To do so, before starting

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -18,7 +18,7 @@
    <para>
     HPC clusters usually consist of a small set of identical compute
     nodes. Each cluster may consist of a mere handful of machines, up to
-    thousands. Managing the compute nodes of a cluster may be challanging. This
+    thousands. Managing the compute nodes of a cluster may be challenging. This
     chapter descibes a number of tools which aid this task.
    </para>
   </abstract>
@@ -30,9 +30,9 @@
  <sect1 xml:id="sec-remote-genders">
   <title>Genders &mdash; static cluster configuration database</title>
   <para>
-   Genders is a static cluster configuration database used for
-   configuration management. It allows grouping and addressing sets of
-   hosts by attributes and is used by a variety of tools. The Genders
+   <emphasis>Genders</emphasis> is a static cluster configuration database used
+   for configuration management. It allows grouping and addressing sets of
+   hosts by attributes, and is used by a variety of tools. The Genders
    database is a text file which is usually replicated on each node in a
    cluster.
   </para>
@@ -55,25 +55,25 @@ nodename1,nodename2,... attr[=value],attr[=value],...
 nodenames[A-B]          attr[=value],attr[=value],...
     </screen>
   <para>
-   The node name(s) do not have domain, and are followed by any number of
+   Node names do not include a domain, and are followed by any number of
    spaces or tabs, then the comma-separated list of attributes. Every
-   attribute can optionally have a value.  The substitution string
+   attribute can optionally have a value. The substitution string
    <literal>%n</literal> can be used in an attribute value to represent the node
    name. Node names can be listed on multiple lines, so a node's attributes can
    be specified on multiple lines. However, no single node may have duplicate
    attributes.
   </para>
   <para>
-   There must be no spaces embedded in the attribute list, and there is
-   no provision for continuation lines.  Commas and equals characters
-   (<literal>=</literal>) are special, and cannot appear in attribute names or
-   values. Comments are prefixed with the hash character (<literal>#</literal>)
-   and can appear anywhere in the file.
+   The attribute list must not contain spaces, and there is no provision for
+   continuation lines.  Commas and equals characters (<literal>=</literal>) are
+   special, and cannot appear in attribute names or values. Comments are
+   prefixed with the hash character (<literal>#</literal>) and can appear
+   anywhere in the file.
   </para>
   <para>
-   Ranges for nodenames can be specified in the form:
+   Ranges for node names can be specified in the form:
    <literal>prefix[n-m,l-k,...]</literal>, where n &gt; m and l &gt; k, etc.,
-   as an alternative to explicit lists of nodenames.
+   as an alternative to explicit lists of node names.
   </para>
   </sect2>
   
@@ -87,7 +87,7 @@ nodenames[A-B]          attr[=value],attr[=value],...
 <screen>nodeattr [-q | -n | -s] [-r] attr[=val]</screen>
   <para>
    where <literal>-q</literal> is the default option and prints a list nodes
-   with <literal>attr[=val]</literal> as hostrange.
+   with <literal>attr[=val]</literal> as the host range.
   </para>
   <para>
    The <literal>-c</literal> options will give a comma-separated list, and the
@@ -96,8 +96,8 @@ nodenames[A-B]          attr[=value],attr[=value],...
   </para>
   <para>
    If none of the formatting options are specified, <command>nodeattr</command>
-   returns a zero value if the local node has the specified attribute, and 
-   otherwise nonzero.  The <literal>-v</literal> option causes any value
+   returns a zero value if the local node has the specified attribute, and
+   non-zero otherwise. The <literal>-v</literal> option causes any value
    associated with the attribute to go to <literal>stdout</literal>. If a node
    name is specified before the attribute, it is queried instead of the
    local node.
@@ -254,40 +254,39 @@ nodenames[A-B]          attr[=value],attr[=value],...
   </important>
  </sect1>
  <sect1 xml:id="sec-remote-munge">
-  <title>Munge authentication</title>
+  <title>MUNGE authentication</title>
   <para>
-   <emphasis>Munge</emphasis> allows for secure communications between
+   <emphasis>MUNGE</emphasis> allows for secure communications between
    different machines which share the same secret key. The most common
    usecase is the <emphasis>Slurm</emphasis> workload manager, which
-   uses <emphasis>munge</emphasis> for the encryption of its messages.
-   Another use case is authentication for the parallel shell
+   uses MUNGE for the encryption of its messages. Another use case is
+   authentication for the parallel shell
    <emphasis>mrsh</emphasis>.
   </para>
   <sect2>
-   <title>Setting up Munge authentication</title>
+   <title>Setting up MUNGE authentication</title>
    <para>
-    <emphasis>Munge</emphasis> uses UID/GID values to uniquely identify
-    and authenticate users. Thus, you must take care that users who will
-    authenicate across a network have unified UIDs and GIDs.
+    MUNGE uses UID/GID values to uniquely identify and authenticate users. Thus,
+    you must take care that users who will authenicate across a network have
+    unified UIDs and GIDs.
    </para>
    <para>
-    <emphasis>Munge</emphasis> credentials have a limited time-to-live.
-    Therefore you must ensure that the time is synchronized across the entire
-    cluster.
+    MUNGE credentials have a limited time-to-live, so you must ensure that the
+    time is synchronized across the entire cluster.
    </para>
    <para>
-    <emphasis>Munge</emphasis> is installed by
-    <command>zypper in munge</command>. This will install all packages required
-    at runtime. A <package>munge-devel</package> package is available to build
-    applications that require <emphasis>munge</emphasis> authentication.
+    MUNGE is installed with the command <command>zypper in munge</command>.
+    This will install all packages required at runtime. A
+    <package>munge-devel</package> package is available to build applications
+    that require <emphasis>munge</emphasis> authentication.
    </para>
    <para>
-    When installing <package>Munge</package>, a new key is generated on
-    every system. However, this <emphasis>Munge</emphasis> key needs to be
-    uniform across the entire cluster. Therefore, the key from one system needs
-    to be copied in a secure way to all other nodes in the cluster. Care must
-    be taken that the key is only readable by the 
-    <literal>munge</literal> user (permissions mask <literal>0400</literal>).
+    When installing the <package>munge</package> package, a new key is generated
+    on every system. However, this MUNGE key must be uniform across the entire
+    cluster. Therefore, the key from one system needs to be copied in a secure
+    way to all other nodes in the cluster. Care must be taken that the key is
+    only readable by the <literal>munge</literal> user (permissions mask
+    <literal>0400</literal>).
    </para>
    <para>
     <emphasis>pdsh</emphasis> (with ssh) may be used to do this:
@@ -311,10 +310,10 @@ pdsh -R ssh -w &lt;hostlist&gt; md5sum /etc/munge/munge.key</screen>
    <para>Make sure that they match.</para>
   </sect2>
   <sect2>
-   <title>Enabling and starting Munge</title>
+   <title>Enabling and starting MUNGE</title>
    <para>
     <systemitem class="daemon">munged</systemitem> needs to be run on all nodes
-    where Munge authentication will take place. If Munge is used for
+    where MUNGE authentication will take place. If MUNGE is used for
     authentication across the network, it needs to run on each side of the
     communications link.
    </para>
@@ -331,10 +330,10 @@ systemctl start munge.service</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-remote-mrsh">
-  <title>mrsh/mrlogin &mdash; remote login using Munge authentication</title>
+  <title>mrsh/mrlogin &mdash; remote login using MUNGE authentication</title>
   <para>
    <emphasis>mrsh</emphasis> is a set of remote shell programs using the
-   <emphasis>Munge</emphasis> authentication system instead of reserved ports
+   <emphasis>MUNGE</emphasis> authentication system instead of reserved ports
    for security.
   </para>
   <para>
@@ -369,11 +368,10 @@ systemctl start munge.service</screen>
   </itemizedlist>
   <para>
    To set up a cluster of machines allowing remote login from each other,
-   first follow the instructions for setting up and starting
-   <emphasis>Munge</emphasis> authentication in <xref linkend="sec-remote-munge"/>.
-   After the <emphasis>Munge</emphasis> service has been successfully
-   started, enable and start <command>mrlogin</command> on each machine on
-   which the user will log in:
+   first follow the instructions for setting up and starting MUNGE
+   authentication in <xref linkend="sec-remote-munge"/>. After the MUNGE service
+   has been successfully started, enable and start <command>mrlogin</command>
+   on each machine on which the user will log in:
   </para>
   <screen>systemctl enable mrlogind.socket mrshd.socket
 systemctl start mrlogind.socket mrshd.socket</screen>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -259,16 +259,16 @@ nodeattr [-f genders] -k
   <para>
    <emphasis>munge</emphasis> allows for a secure communication between
    different machines which share the same secret key. The most common
-   usecase is the <emphasis>slurm</emphasis> workload mangager which
+   usecase is the <emphasis>slurm</emphasis> workload manager which
    uses <emphasis>munge</emphasis> for the encryption of its messages.
-   Another usecase is authentification for the parallel shell
+   Another usecase is authentication for the parallel shell
    <emphasis>mrsh</emphasis>.
   </para>
   <sect2>
    <title>Setting up MUNGE authentication</title>
    <para>
     <emphasis>Munge</emphasis> uses the UID/GID to uniquely identify
-    and authenciate users. This care must be taken that the users who
+    and authenticate users. Thus, care must be taken that the users who
     are to be authenicated across a network have unified UIDs and GIDs.
    </para>
    <para>
@@ -277,13 +277,13 @@ nodeattr [-f genders] -k
     the entire cluster.
    </para>
    <para>
-    <emphasis>Munge</emphasis> is installed by <command>zypper</command>
-    in munge'. This will install all packages required at runtime. A
-    'munge-devel' package is available to build applications that require
-    munge authentication.
+    <emphasis>Munge</emphasis> is installed by
+    <command>zypper in munge</command>. This will install all packages required
+    at runtime. A 'munge-devel' package is available to build applications that
+    require <emphasis>munge</emphasis> authentication.
    </para>
    <para>
-    When installing <emphasis>munge</emphasis> a new key is generated on
+    When installing <emphasis>munge</emphasis>, a new key is generated on
     every system. The <emphasis>munge</emphasis> key needs to be uniform
     across the entire cluster, however. Therefore a key of one system
     needs to be copied in a secure way to all other nodes in the cluster.

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -321,11 +321,14 @@ nodeattr [-f genders] -k
     across the network it needs to run on each side of the communication.
    </para>
    <para>
-    To start the service and make sure it is started after every reboot, run</para>
-    <screen>systemctl enable munge.service
-    systemctl start munge.service</screen>
-    <para>on each node. To perform the same on multiple nodes, pdsh may be employed
-    as well.
+    To start the service and make sure it is started after every reboot, on each
+    node, run:
+   </para>
+<screen>systemctl enable munge.service
+systemctl start munge.service</screen>
+    <para>
+     To perform the same on multiple nodes, you can also use
+     <command>pdsh<command>.
    </para>
   </sect2>
  </sect1>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -328,7 +328,7 @@ nodeattr [-f genders] -k
 systemctl start munge.service</screen>
     <para>
      To perform the same on multiple nodes, you can also use
-     <command>pdsh<command>.
+     <command>pdsh</command>.
    </para>
   </sect2>
  </sect1>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -39,7 +39,7 @@
   <para>
    Perl, Python, Lua, C, and C++ bindings are supplied with Genders. Each
    package provides <command>man</command> pages or other documentation which
-   describe the APIs.
+   describes the APIs.
   </para>
   <sect2 xml:id="sec-genders-db">
     <title>Genders database format</title>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -279,7 +279,7 @@ nodeattr [-f genders] -k
    <para>
     <emphasis>Munge</emphasis> is installed by
     <command>zypper in munge</command>. This will install all packages required
-    at runtime. A 'munge-devel' package is available to build applications that
+    at runtime. A <package>munge-devel</package> package is available to build applications that
     require <emphasis>munge</emphasis> authentication.
    </para>
    <para>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -17,10 +17,9 @@
   <abstract>
    <para>
     HPC clusters usually consist of a small set of identical compute
-    nodes. Each set of nodes may consist from a mere handful to thousands
-    of machines.
-    Managing such compute nodes may be challanging. This chaper
-    descibes a number of tools which aid this task.
+    nodes. Each cluster may consist of a mere handful of machines, up to
+    thousands. Managing the compute nodes of a cluster may be challanging. This
+    chapter descibes a number of tools which aid this task.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -38,16 +37,17 @@
    cluster.
   </para>
   <para>
-   Perl, Python, Lua, C, and C++ bindings are supplied with Genders, the
-   respective packages provide man pages or other documentation describing
-   the APIs.
+   Perl, Python, Lua, C, and C++ bindings are supplied with Genders. Each
+   package provides <command>man</command> pages or other documentation which
+   describe the APIs.
   </para>
   <sect2 xml:id="sec-genders-db">
     <title>Genders database format</title>
   <para>
-    The Genders database in &shpca; is the plain-text file <filename>/etc/genders</filename>.
-    It contains a list of nodenames with their attributes. Each line of
-    the genders file may have one of the following formats.
+   The Genders database in &shpca; is a plain-text file
+   <filename>/etc/genders</filename>. It contains a list of node names with
+   their attributes. Each line of the database may have one of the following
+   formats.
   </para>
     <screen>
 nodename                attr[=value],attr[=value],...
@@ -55,84 +55,83 @@ nodename1,nodename2,... attr[=value],attr[=value],...
 nodenames[A-B]          attr[=value],attr[=value],...
     </screen>
   <para>
-    The nodename(s) are without their domain and followed by any number of
-    spaces or tabs, and then the comma-separated list of attributes. Every
-    attribute can optionally have a value.  The substitution string "%n" can
-    be used in an attribute value to represent the nodename.  Nodenames can be
-    listed on multiple lines, so a node's attributes can be specified on multiple
-    lines.  However, no single node may have duplicate attributes.
+   The node name(s) do not have domain, and are followed by any number of
+   spaces or tabs, then the comma-separated list of attributes. Every
+   attribute can optionally have a value.  The substitution string
+   <literal>%n</literal> can be used in an attribute value to represent the node
+   name. Node names can be listed on multiple lines, so a node's attributes can
+   be specified on multiple lines. However, no single node may have duplicate
+   attributes.
   </para>
   <para>
-    There must be no spaces embedded in the attribute list and there is
-    no provision for continuation lines.  Commas and equal characters are special
-    and cannot appear in attribute names or their values.  Comments are prefixed
-    with the hash character (#) and can appear anywhere in the file.
+   There must be no spaces embedded in the attribute list, and there is
+   no provision for continuation lines.  Commas and equals characters
+   (<literal>=</literal>) are special, and cannot appear in attribute names or
+   values. Comments are prefixed with the hash character (<literal>#</literal>)
+   and can appear anywhere in the file.
   </para>
   <para>
-    Ranges for nodenames can be specified in the form:
-    prefix[n-m,l-k,...], where n &gt; m and l &gt; k, etc., as an alternative
-    to explicit lists of nodenames.
+   Ranges for nodenames can be specified in the form:
+   <literal>prefix[n-m,l-k,...]</literal>, where n &gt; m and l &gt; k, etc.,
+   as an alternative to explicit lists of nodenames.
   </para>
   </sect2>
+  
   <sect2 xml:id="sec-nodeattr">
-    <title>Nodeattr usage</title>
-  <para>
-    The command line utitlity <literal>nodeaddr</literal> can be used to query data
+   <title>Nodeattr usage</title>
+   <para>
+    The command line utility <command>nodeaddr</command> can be used to query data
     in the genders file. When the genders file is replicated on all nodes, a qery
     can be done wihtout network access. It can be called like followed
-  </para>
-  <screen>
-nodeattr [-q | -n | -s] [-r] attr[=val]
-  </screen>
+   </para>
+<screen>nodeattr [-q | -n | -s] [-r] attr[=val]</screen>
   <para>
-    where <literal>-q</literal> is the default option and prints a list nodes
-    with <literal>attr[=val]</literal> as hostrange.
+   where <literal>-q</literal> is the default option and prints a list nodes
+   with <literal>attr[=val]</literal> as hostrange.
   </para>
   <para>
-    The <literal>-c</literal> options will give a comma separated, the
-    <literal>-s</literal> option a space seperated list of nodes with
-    <literal>attr[=val]</literal>.
+   The <literal>-c</literal> options will give a comma-separated list, and the
+   <literal>-s</literal> option a space-separated list, of nodes with 
+   <literal>attr[=val]</literal>.
   </para>
   <para>
-    If none of the formatting options are specified, nodeattr returns a zero
-    value if the local node has the specified attribute, else nonzero.  The
-    <literal>-v</literal> option causes any value associated with the attribute
-    to go to stdout. If a node name is specified before the attribute, it is
-    queried instead of the
-    local node.
+   If none of the formatting options are specified, <command>nodeattr</command>
+   returns a zero value if the local node has the specified attribute, and 
+   otherwise nonzero.  The <literal>-v</literal> option causes any value
+   associated with the attribute to go to <literal>stdout</literal>. If a node
+   name is specified before the attribute, it is queried instead of the
+   local node.
   </para>
   <para>
-    When <literal>nodeattr</literal> is called with the <literal>-l</literal>
-    parameter like
+    When <command>nodeattr</command> is called with the <literal>-l</literal>
+    parameter, as follows:
   </para>
-    <screen>
-nodeattr -l [node]
-    </screen>
-      <para>
-        all attributes for a particular node are printed out. If no node paramteter is
-        is given, all attributes of the local node are printed out.
-      </para>
-      <para>
-        With the command
-       </para>
-        <screen>
-nodeattr [-f genders] -k
-        </screen>
-        <para>
-          a syntax check of the genders database is performed, where with the switch
-          <literal>-f</literal> an alternative datanbase location can be specified.
-        </para>
-  </sect2>
+<screen>nodeattr -l [node]</screen>
+  <para>
+   all attributes for a particular node are printed out. If no node
+   paramteter is is given, all attributes of the local node are printed out.
+  </para>
+  <para>
+   With the command
+  </para>
+<screen>nodeattr [-f genders] -k</screen>
+  <para>
+   a syntax check of the genders database is performed, where with the switch
+   <literal>-f</literal> an alternative datanbase location can be specified.
+  </para>
+ </sect2>
+  
  </sect1>
  <sect1 xml:id="sec-remote-pdsh">
   <title>pdsh &mdash; parallel remote shell program</title>
   <para>
-   <literal>pdsh</literal> is a parallel remote shell which can be used
+   <command>pdsh</command> is a parallel remote shell which can be used
    with multiple back-ends for remote connections. It can run a command on
    multiple machines in parallel.
   </para>
   <para>
-   To install pdsh, run <command>zypper in pdsh</command>.
+   To install <package>pdsh</package>, run the command:
+   <command>zypper in pdsh</command>.
   </para>
   <para>
    On &shpca; the back-ends <literal>ssh</literal>,
@@ -255,41 +254,40 @@ nodeattr [-f genders] -k
   </important>
  </sect1>
  <sect1 xml:id="sec-remote-munge">
-  <title>MUNGE authentication</title>
+  <title>Munge authentication</title>
   <para>
-   <emphasis>munge</emphasis> allows for a secure communication between
+   <emphasis>Munge</emphasis> allows for secure communications between
    different machines which share the same secret key. The most common
-   usecase is the <emphasis>slurm</emphasis> workload manager which
+   usecase is the <emphasis>Slurm</emphasis> workload manager, which
    uses <emphasis>munge</emphasis> for the encryption of its messages.
    Another use case is authentication for the parallel shell
    <emphasis>mrsh</emphasis>.
   </para>
   <sect2>
-   <title>Setting up MUNGE authentication</title>
+   <title>Setting up Munge authentication</title>
    <para>
-    <emphasis>Munge</emphasis> uses the UID/GID to uniquely identify
-    and authenticate users. Thus, care must be taken that the users who
-    are to be authenicated across a network have unified UIDs and GIDs.
+    <emphasis>Munge</emphasis> uses UID/GID values to uniquely identify
+    and authenticate users. Thus, you must take care that users who will
+    authenicate across a network have unified UIDs and GIDs.
    </para>
    <para>
     <emphasis>Munge</emphasis> credentials have a limited time-to-live.
-    Therefore it must be ensured  that the time is synchronized across
-    the entire cluster.
+    Therefore you must ensure that the time is synchronized across the entire
+    cluster.
    </para>
    <para>
     <emphasis>Munge</emphasis> is installed by
     <command>zypper in munge</command>. This will install all packages required
-    at runtime. A <package>munge-devel</package> package is available to build applications that
-    require <emphasis>munge</emphasis> authentication.
+    at runtime. A <package>munge-devel</package> package is available to build
+    applications that require <emphasis>munge</emphasis> authentication.
    </para>
    <para>
-    When installing <emphasis>munge</emphasis>, a new key is generated on
-    every system. The <emphasis>munge</emphasis> key needs to be uniform
-    across the entire cluster, however. Therefore a key of one system
-    needs to be copied in a secure way to all other nodes in the cluster.
-    Care must be taken that the key is only readable by the
-    <emphasis>'munge'</emphasis> user (permissions mask
-    <literal>0400</literal>).
+    When installing <package>Munge</package>, a new key is generated on
+    every system. However, this <emphasis>Munge</emphasis> key needs to be
+    uniform across the entire cluster. Therefore, the key from one system needs
+    to be copied in a secure way to all other nodes in the cluster. Care must
+    be taken that the key is only readable by the 
+    <literal>munge</literal> user (permissions mask <literal>0400</literal>).
    </para>
    <para>
     <emphasis>pdsh</emphasis> (with ssh) may be used to do this:
@@ -298,27 +296,27 @@ nodeattr [-f genders] -k
     Check permissions, owner and file type of the key file located under
     <filename>/etc/munge/munge.key</filename> on the local system:
    </para>
-   <screen># stat --format "%F %a %G %U %n" /etc/munge/munge.key</screen>
+<screen># stat --format "%F %a %G %U %n" /etc/munge/munge.key</screen>
    <para>The settings should be:</para>
-   <screen>400 regular file munge munge /etc/munge/munge.key</screen>
+<screen>400 regular file munge munge /etc/munge/munge.key</screen>
    <para>Get md5sum of munge.key:</para>
-   <screen># md5sum /etc/munge/munge.key</screen>
+<screen># md5sum /etc/munge/munge.key</screen>
    <para>Copy key to list of nodes:</para>
-   <screen># pdcp -R ssh -w &lt;hostlist&gt; /etc/munge/munge.key
+<screen># pdcp -R ssh -w &lt;hostlist&gt; /etc/munge/munge.key
    /etc/munge/munge.key </screen>
    <para>Check key settings in remote host:</para>
-   <screen>pdsh -R ssh -w &lt;hostlist&gt; stat --format \"%F %a %G %U %n\"
-   /etc/munge/munge.key
-   pdsh -R ssh -w &lt;hostlist&gt; md5sum /etc/munge/munge.key
-   </screen>
-   <para>make sure they match.</para>
+<screen>pdsh -R ssh -w &lt;hostlist&gt; stat --format \"%F %a %G %U %n\"
+/etc/munge/munge.key
+pdsh -R ssh -w &lt;hostlist&gt; md5sum /etc/munge/munge.key</screen>
+   <para>Make sure that they match.</para>
   </sect2>
   <sect2>
-   <title>Enabling and starting MUNGE</title>
+   <title>Enabling and starting Munge</title>
    <para>
-    <emphasis>munged</emphasis> needs to be run on all nodes where munge
-    authentication is to take place. If munge is used for authentication
-    across the network it needs to run on each side of the communication.
+    <systemitem class="daemon">munged</systemitem> needs to be run on all nodes
+    where Munge authentication will take place. If Munge is used for
+    authentication across the network, it needs to run on each side of the
+    communications link.
    </para>
    <para>
     To start the service and make sure it is started after every reboot, on each
@@ -333,10 +331,10 @@ systemctl start munge.service</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-remote-mrsh">
-  <title>mrsh/mrlogin &mdash; remote login using MUNGE authentication</title>
+  <title>mrsh/mrlogin &mdash; remote login using Munge authentication</title>
   <para>
    <emphasis>mrsh</emphasis> is a set of remote shell programs using the
-   <emphasis>munge</emphasis> authentication system instead of reserved ports
+   <emphasis>Munge</emphasis> authentication system instead of reserved ports
    for security.
   </para>
   <para>
@@ -372,8 +370,8 @@ systemctl start munge.service</screen>
   <para>
    To set up a cluster of machines allowing remote login from each other,
    first follow the instructions for setting up and starting
-   <emphasis>munge</emphasis> authentication in <xref linkend="sec-remote-munge"/>.
-   After <emphasis>munge</emphasis> service has been successfully
+   <emphasis>Munge</emphasis> authentication in <xref linkend="sec-remote-munge"/>.
+   After the <emphasis>Munge</emphasis> service has been successfully
    started, enable and start <command>mrlogin</command> on each machine on
    which the user will log in:
   </para>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -261,7 +261,7 @@ nodeattr [-f genders] -k
    different machines which share the same secret key. The most common
    usecase is the <emphasis>slurm</emphasis> workload manager which
    uses <emphasis>munge</emphasis> for the encryption of its messages.
-   Another usecase is authentication for the parallel shell
+   Another use case is authentication for the parallel shell
    <emphasis>mrsh</emphasis>.
   </para>
   <sect2>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -156,17 +156,17 @@ nodeattr [-f genders] -k
    <xref linkend="sec-remote-mrsh"/>
   </para>
   <para>
-   Remote machines can either be specified on the command line or
+   Remote machines can be specified on the command line, or
    <command>pdsh</command> can use a <filename>machines</filename> file
-   (<filename>/etc/pdsh/machines</filename>), dsh (Dancer's shell) style
-   groups or netgroups. Also, it can target nodes based on the currently
-   running Slurm jobs.
+   (<filename>/etc/pdsh/machines</filename>), <command>dsh</command> (Dancer's
+   shell)-style groups or netgroups. Also, it can target nodes based on the
+   currently running Slurm jobs.
   </para>
   <para>
    The different ways to select target hosts are realized by modules. Some
    of these modules provide identical options to <command>pdsh</command>.
-   The module loaded first will win and consume the option. Therefore, it is
-   recommended to limit yourself to a single method and specifying this with
+   The module loaded first will win and handle the option. Therefore, we
+   recommended limiting yourself to a single method and specifying this with
    the <literal>-M</literal> option.
   </para>
   <para>
@@ -179,15 +179,15 @@ nodeattr [-f genders] -k
    <literal>machines</literal>, <literal>slurm</literal>,
    <literal>netgroup</literal> and <literal>dshgroup</literal>.
    Each host-list plugin is provided in a separate package. This avoids
-   conflicts between command line options for different plugins which
-   happen to be identical and helps to keep installations small and free
+   conflicts between command-line options for different plugins which
+   happen to be identical, and helps to keep installations small and free
    of unneeded dependencies. Package dependencies have been set to prevent
-   installing plugins with conflicting command options. To install one of
-   the plugins, run:
+   the installation of plugins with conflicting command options. To install one
+   of the plugins, run:
   </para>
-  <screen>zypper in pdsh-<replaceable>PLUGIN_NAME</replaceable></screen>
+<screen>zypper in pdsh-<replaceable>PLUGIN_NAME</replaceable></screen>
   <para>
-   For more information, see the man page <command>pdsh</command>.
+   For more information, see the <command>man</command> page <command>pdsh</command>.
   </para>
  </sect1>
  <sect1 xml:id="sec-remote-powerman">

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -13,24 +13,24 @@
   <abstract>
    <para>
     <emphasis>Slurm</emphasis> is a workload manager for managing compute jobs
-    on high performance computing cluster. It can start multiple jobs on a
+    on high performance computing clusters. It can start multiple jobs on a
     single node or a single job on multiple nodes. Additional components can be
     used for advanced scheduling and accounting.
    </para>
 
    <para>
-    The mandatory components of <emphasis>Slurm</emphasis> is the control
-    daemon <emphasis>slurmctld</emphasis> taking care of job scheduling and the
+    The mandatory components of <emphasis>Slurm</emphasis> are the control
+    daemon <emphasis>slurmctld</emphasis> taking care of job scheduling, and the
     slurm daemon <emphasis>slurmd</emphasis> responsible for launching compute
-    jobs. Subsequently nodes running the control daemon are called master nodes
+    jobs. Subsequently, nodes running the control daemon are called master nodes
     and nodes running the <emphasis>slurmd</emphasis> are called compute nodes.
    </para>
 
    <para>
     Additional components are a secondary <emphasis>slurmctld</emphasis> acting
-    as standby server for a failover and the slurm database daemon
+    as standby server for a failover, and the slurm database daemon
     <emphasis>slurmdbd</emphasis> which stores the job history and user
-    hirachy.
+    hierarchy.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -42,8 +42,8 @@
   <title>Slurm — utility for HPC workload management</title>
 
   <para>
-   For a minimal setup of <emphasis>Slurm</emphasis> with a controll node and
-   multiple cmpute nodes, follow these instructions:
+   For a minimal setup of <emphasis>Slurm</emphasis> with a control node and
+   multiple compute nodes, follow these instructions:
   </para>
 
   <sect2 xml:id="sec-slurm-minimal">
@@ -83,9 +83,9 @@
     <step>
      <para>
       Install <package>slurm-node</package> on the compute nodes with
-      <command>zypper in slurm-node</command> and <package>slurm</package> on
-      the controll node with <command>zypper in slurm</command>. The package
-      <package>munge</package>will be installed as dependence automatically.
+      <command>zypper in slurm-node</command>, and <package>slurm</package> on
+      the control node with <command>zypper in slurm</command>. The package
+      <package>munge</package>will automatically be installed as a dependency.
      </para>
     </step>
    </procedure>
@@ -235,10 +235,10 @@ sbatch sleeper.sh
   <sect2 xml:id="sec-slurm-slurmdbd">
    <title>Install slurm database</title>
    <para>
-    With the minimal installation slurm will only store pending and running
+    With the minimal installation, slurm will only store pending and running
     jobs. In order to store to finished and failed job data, the storage plugin
-    has to be installed and enabled. Additionally so called completely fair
-    scheduling can be enable, which replaces the FIFO
+    has to be installed and enabled. Additionally, so-called completely fair
+    scheduling can be enabled, which replaces the FIFO
     <footnote>
      <para>
       <emphasis>f</emphasis>irst <emphasis>i</emphasis>n
@@ -249,11 +249,11 @@ sbatch sleeper.sh
     dependence of the job which a user has run in the history.
    </para>
    <para>
-    The slurm database has two components which is the daemon
-    <literal>slurmdbd</literal> itself and a mysql database, where
-    <literal>mariab</literal> is recommended. The database can be on the same
+    The slurm database has two components: the <literal>slurmdbd</literal>
+    daemon itself, and a MySQL database, where <literal>mariab</literal> is
+    recommended. The database can be on the same
     node which runs <literal>slurmdbd</literal> or another node. For this
-    simple setup all these services run on the same node.
+    simple setup, all these services run on the same node.
    </para>
    <procedure>
     <title>Install <package>slurmdbd</package></title>
@@ -286,17 +286,17 @@ systemctl enable mariadb</screen>
     </step>
     <step xml:id="sec-sum-sqldb">
      <para>
-      In this step the database and the user for the slurm database has to be
-      created. This is done by connecting to the SQL database with e.g. the
-      command <command>mysql -u root -p</command>. After a successful
-      connection the database and the creation of secure password
+      In this step, the database and the user for the slurm database have to be
+      created. This is done by connecting to the SQL database, for example with
+      the command <command>mysql -u root -p</command>. After a successful
+      connection, the database and the creation of a secure password
       <footnote>
        <para>
         You can use the command <command>openssl rand -base64 32</command> to
         create a secure random password
        </para>
       </footnote>
-      , the slurm user and the database is created with the commands
+      , the slurm user and the database are created with the commands
      </para>
 <screen>
 create user 'slurm'@'localhost' identified by 'password';

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -682,11 +682,10 @@ Description="subgroup" Organization=bavaria</screen>
         <listitem>
          <para>
           means that the signal specified by <replaceable>NUMBER</replaceable>
-          will be sent, 60 seconds before the end of the job unless
-          <replaceable>TIME</replaceable>
-          was specified. The signal will be sent to every process on every node.
-          If a signal should only be sent to the controlling batch job, you
-          must specify the <command>B:</command> flag.
+          will be sent 60 seconds before the end of the job, unless
+          <replaceable>TIME</replaceable> was specified. The signal will be sent
+          to every process on every node. If a signal should only be sent to the
+          controlling batch job, you must specify the <command>B:</command> flag.
          </para>
         </listitem>
        </varlistentry>
@@ -723,8 +722,8 @@ Description="subgroup" Organization=bavaria</screen>
         <listitem>
          <para>
           run a job only on nodes with the specified <emphasis>generic
-          resource</emphasis>, for example a GPU, specified by the value of
-          <replaceable>GRES</replaceable>.
+          resource</emphasis> (GRes), for example a GPU, specified by the value
+          of <replaceable>GRES</replaceable>.
          </para>
         </listitem>
        </varlistentry>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -77,7 +77,7 @@
      </para>
      <para>
       Configure, enable and start <command>munge</command> on the control and
-      compute nodes as described in <xref linkend="sec-remote-munge"/>.
+      compute nodes, as described in <xref linkend="sec-remote-munge"/>.
      </para>
     </step>
     <step>
@@ -85,7 +85,7 @@
       Install <package>slurm-node</package> on the compute nodes with
       <command>zypper in slurm-node</command>, and <package>slurm</package> on
       the control node with <command>zypper in slurm</command>. The package
-      <package>munge</package>will automatically be installed as a dependency.
+      <package>munge</package> will automatically be installed as a dependency.
      </para>
     </step>
    </procedure>
@@ -110,7 +110,7 @@
       </step>
       <step>
        <para>
-        In order to define the compute nodes add:
+        In order to define the compute nodes, add:
        </para>
 <screen>NodeName=<replaceable>NODE_LIST</replaceable>  State=UNKNOWN</screen>
        <para>
@@ -258,22 +258,22 @@ sbatch sleeper.sh
    <procedure>
     <title>Install <package>slurmdbd</package></title>
     <note>
-     <title>Mariadb</title>
+     <title>MariaDB</title>
      <para>
       If you want to use an external SQL database (or such a database is
-      already installed on the control node), you can skip the Mariadb-related
+      already installed on the control node), you can skip the MariaDB-related
       steps.
      </para>
     </note>
     <step>
      <para>
-      Install the Mariabd SQL database with <command>zypper in
+      Install the MariaDB SQL database with <command>zypper in
       mariadb</command>.
      </para>
     </step>
     <step>
      <para>
-      Start and enable Mariadb with the following commands:
+      Start and enable MariaDB with the following commands:
      </para>
 <screen>systemctl start mariadb
 systemctl enable mariadb</screen>
@@ -357,17 +357,17 @@ AccountingStorageHost=localhost</screen>
     </step>
     <step performance="optional">
      <para>
-      Per default <literal>slurm</literal> does not take any group membership
+      By default, <literal>slurm</literal> does not take any group membership
       into account and it is not possible to map the system groups to
-      <literal>slurm</literal>. The creation and group membership have to
-      managed via the commandline tool <command>sacctmgr</command>. Its also
-      possible to have a group hierarchy and users can be part of several
+      <literal>slurm</literal>. Group creation and membership have to be
+      managed via the command line tool <command>sacctmgr</command>. It is also
+      possible to have a group hierarchy, and users can be part of several
       groups.
      </para>
      <para>
       To create an umbrella group <literal>bavaria</literal> for two subgroups
-      called <literal>nuremberg</literal> and <literal>munich</literal> use
-      following commands
+      called <literal>nuremberg</literal> and <literal>munich</literal>, use
+      the following commands:
      </para>
 <screen>sacctmgr add account bavaria \
   Description="umbrella group for subgroups" Organization=bavaria
@@ -388,14 +388,14 @@ Description="subgroup" Organization=bavaria</screen>
    <title>scontrol</title>
    <para>
     The command <command>scontrol</command> is used to show and update the
-    entities of <literal>slurm</literal> like the state of the compute nodes or
-    compute jobs. It can also be used to reboot or propagate configuration
+    entities of <literal>slurm</literal>, such as the state of the compute nodes
+    or compute jobs. It can also be used to reboot or to propagate configuration
     changes to the compute nodes.
    </para>
    <para>
-    Useful options to this command are <literal>--details</literal> which will
-    print a more verbose output and <literal>--oneliner</literal> forcing the
-    output to a single what is useful for scripts.
+    Useful options to this command are <literal>--details</literal>, which will
+    print more verbose output, and <literal>--oneliner</literal>, which forces
+    the output onto a single line, which is more useful in shell scripts.
    </para>
    <variablelist>
     <varlistentry>
@@ -515,16 +515,16 @@ Description="subgroup" Organization=bavaria</screen>
      <term><command>sinfo</command></term>
      <listitem>
       <para>
-       retrieves information about the state of the compute nodes and can be
-       used for a fast overview of the cluster health. Following commandline
-       switches are available
+       retrieves information about the state of the compute nodes, and can be
+       used for a fast overview of the cluster health. The following comman
+       line switches are available:
       </para>
       <variablelist>
        <varlistentry>
         <term><command>--dead</command></term>
         <listitem>
          <para>
-          displays information about not responding nodes.
+          displays information about unresponsive nodes.
          </para>
         </listitem>
        </varlistentry>
@@ -532,7 +532,7 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--long</command></term>
         <listitem>
          <para>
-          use this switch for more detailed information.
+          shows more detailed information.
          </para>
         </listitem>
        </varlistentry>
@@ -540,7 +540,7 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--reservation</command></term>
         <listitem>
          <para>
-          print information about advanced reservations.
+          prints information about advanced reservations.
          </para>
         </listitem>
        </varlistentry>
@@ -549,7 +549,7 @@ Description="subgroup" Organization=bavaria</screen>
         <listitem>
          <para>
           displays the reason why a node is in the <literal>down</literal>,
-          <literal>drained</literal> or <literal>failing</literal> state.
+          <literal>drained</literal>, or <literal>failing</literal> state.
          </para>
         </listitem>
        </varlistentry>
@@ -557,8 +557,8 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--state=<replaceable>STATE</replaceable></command></term>
         <listitem>
          <para>
-          limit the output only to computes with the given state
-          <replaceable>STATE</replaceable>.
+          limit the output only to nodes with the specified
+          <replaceable>STATE</replaceable> state.
          </para>
         </listitem>
        </varlistentry>
@@ -569,8 +569,8 @@ Description="subgroup" Organization=bavaria</screen>
      <term><command>sacct</command></term>
      <listitem>
       <para>
-       displays, when accounting is enabled, the accounting data. Following
-       options are available
+       when accounting is enabled, displays the accounting data. The following
+       options are available:
       </para>
       <variablelist>
        <varlistentry>
@@ -585,7 +585,7 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--accounts</command>=<replaceable>NAME</replaceable></term>
         <listitem>
          <para>
-          only specified user(s) are shown
+          only the specified user(s) are shown
          </para>
         </listitem>
        </varlistentry>
@@ -595,9 +595,9 @@ Description="subgroup" Organization=bavaria</screen>
          <para>
           only jobs after starttime will be showed. It also possible to have
           just <replaceable>MM/DD</replaceable> or
-          <replaceable>HH:MM</replaceable>. If not time is given
-          <literal>00:00</literal>, what means that only job from this day are
-          showed.
+          <replaceable>HH:MM</replaceable>. If no time is given, defaults to
+          <literal>00:00</literal>, what means that only jobs from this day are
+          shown.
          </para>
         </listitem>
        </varlistentry>
@@ -605,7 +605,7 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--endtime</command>=<replaceable>MM/DD[/YY]-HH:MM[:SS]</replaceable></term>
         <listitem>
          <para>
-          same option as for <command>--starttime</command>. If not set, the
+          same options as for <command>--starttime</command>. If not set, the
           time when the command was issued is used.
          </para>
         </listitem>
@@ -622,7 +622,7 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--partition</command>=<replaceable>PARTITION</replaceable></term>
         <listitem>
          <para>
-          show only job which run <replaceable>PARTITION</replaceable>.
+          show only jobs which run in <replaceable>PARTITION</replaceable>.
          </para>
         </listitem>
        </varlistentry>
@@ -633,14 +633,14 @@ Description="subgroup" Organization=bavaria</screen>
      <term><command>sbatch</command>, <command>salloc</command> and <command>srun</command></term>
      <listitem>
       <para>
-       this commands are used schedule a compute job, which is a batch script
-       for <command>sbatch</command>, a interactive session for
-       <command>salloc</command> and a binary for <command>srun</command>.
-       Please note that only the command <command>sbatch</command> will place
-       the submitted job script to the queue if it can't scheduled immediately.
+       these commands are used to schedule a compute job, which is a batch script
+       for the <command>sbatch</command> command, a interactive session for
+       <command>salloc</command>, and a binary for <command>srun</command>.
+       Please note that only <command>sbatch</command> will place the submitted
+       job script into the queue if it can not be scheduled immediately.
       </para>
       <para>
-       Frequently used options for this commands are:
+       Some frequently-used options for this commands are:
       </para>
       <variablelist>
        <varlistentry>
@@ -764,22 +764,21 @@ Description="subgroup" Organization=bavaria</screen>
   <title>Upgrading Slurm</title>
    <para>
   New major versions of Slurm are released in regular intervals. With some
-  restrictions (see below), interoperability is guaranteed between 3 consecutive
-  versions. However, unlike updates to maintenance releases (that is releases
-  which differ in the last version number), upgrades to later major versions
-  may require more careful planning.
+  restrictions (see below), interoperability is guaranteed between three
+  consecutive versions. However, unlike updates to maintenance releases (that
+  is, releases which differ in the last version number), upgrades to later major
+  versions may require more careful planning.
  </para>
  <para>
-  For existing products under general support version upgrades of Slurm are
+  For existing products under general support, version upgrades of Slurm are
   provided regularly. Unlike maintenance updates, these upgrades will not be
   installed automatically using <literal>zypper patch</literal> but require the
-  administrator to request their installation explicitly. This is to ensures
+  administrator to request their installation explicitly. This is to ensure
   that these upgrades are not installed unintentionally and gives the
   administrator the opportunity to plan version upgrades beforehand.
  </para>
  <para>
-  On new installations, we recommend installing the latest available
-  version.
+  On new installations, we recommend installing the latest available version.
  </para>
  <para>
   Slurm uses a segmented version number: The first two segments denote the
@@ -789,8 +788,8 @@ Description="subgroup" Organization=bavaria</screen>
   Check the list below for available major versions.
  </para>
  <para>
-  Upgrade packages (that is packages that have not been supplied with the
-  module or service pack initially) have their major version encoded in the
+  Upgrade packages (that is, packages that were not initially supplied with the
+  module or service pack) have their major version encoded in the
   package name (with periods <literal>.</literal> replaced by underscores
   <literal>_</literal>). For example, for version 18.08, this would be:
   <literal>slurm_18_08-*.rpm</literal>.
@@ -803,7 +802,7 @@ Description="subgroup" Organization=bavaria</screen>
   To upgrade Slurm subpackages, proceed analogously.
  </para>
  <para>
-  In addition to the <quote>3 major version rule</quote> mentioned at the
+  In addition to the <quote>the major version rule</quote> mentioned at the
   beginning of this section, obey the following rules regarding the order of
   updates:
  </para>
@@ -1307,6 +1306,7 @@ SlurmdTimeout=3600</screen>
   </para>
  </sect2>
  </sect1>
+ 
  <sect1 xml:id="sec-slurm-additional-res">
   <title>Additional resources</title>
   <sect2 xml:id="sec-slurm-faq">
@@ -1318,32 +1318,54 @@ SlurmdTimeout=3600</screen>
       </question>
        <answer>
         <para>
-		When the <literal>slurmd</literal> daemon on a node does not reboot in the time given by the <literal>ResumeTimeout</literal> parameter or the <literal>ReturnToService</literal> was not changed in the configuration file <filename>slurm.conf</filename>, compute nodes stay in the <literal>down</literal> state and have to be set back to the <literal>up</literal> state manually. This can be done for the <replaceable>NODE</replaceable> with the following command:</para>
-        <screen>scontrol update state=resume NodeName=NODE</screen>
+         When the <literal>slurmd</literal> daemon on a node does not reboot in
+         the time given by the <literal>ResumeTimeout</literal> parameter, or
+         the <literal>ReturnToService</literal> was not changed in the
+         configuration file <filename>slurm.conf</filename>, compute nodes stay
+         in the <literal>down</literal> state and have to be set back to the
+         <literal>up</literal> state manually. This can be done for the
+         <replaceable>NODE</replaceable> with the following command:
+        </para>
+<screen>scontrol update state=resume NodeName=<replaceable>NODE</replaceable></screen>
        </answer>
     </qandaentry>
     <qandaentry>
       <question>
-       <para>What is the difference between the state <literal>down</literal> and <literal>down*</literal>?</para>
+       <para>
+        What is the difference between the state <literal>down</literal> and
+        <literal>down*</literal>?
+       </para>
       </question>
       <answer>
        <para>
-           When a node is marked as <literal>down</literal> this means that the node is not reachable due to network issues or the <literal>slurmd</literal> is not running. In the <literal>down</literal> state the node is reachable, but the node was rebooted unexpectedly, the hardware does not match the description in <filename>slurm.conf</filename> or a healthcheck configured with the <literal>HealthCheckProgram</literal>.
+        When a node is marked as <literal>down</literal>, this means that the
+        node is not reachable due to network issues or the
+        <literal>slurmd</literal> is not running. In the <literal>down</literal>
+        state, the node is reachable, but the node was rebooted unexpectedly,
+        the hardware does not match the description in
+        <filename>slurm.conf</filename>, or a healthcheck was configured with
+        the <literal>HealthCheckProgram</literal>.
        </para>
       </answer>
     </qandaentry>
     <qandaentry>
       <question>
-       <para>How do I get the exact core count, socket number and number of CPUs for a node?</para>
+       <para>
+        How do I get the exact core count, socket number and number of CPUs for
+        a node?
+       </para>
       </question>
       <answer>
        <para>
-		 The values for a node which go into the configuration file <filename>slurm.conf</filename> can be obtained with the command</para>
-       <screen>slurmd -C</screen>
+        The values for a node which go into the configuration file
+        <filename>slurm.conf</filename> can be obtained with the command:
+       </para>
+<screen>slurmd -C</screen>
       </answer>
     </qandaentry>
    </qandaset>
   </sect2>
+  
   <sect2 xml:id="sec-slurm-ext-doc">
    <title>External documentation</title>
    <para>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -76,7 +76,7 @@
       directory.
      </para>
      <para>
-      Configure, enable and start <emphasis>munge</emphasis> on the control and
+      Configure, enable and start <command>munge</command> on the control and
       compute nodes as described in <xref linkend="sec-remote-munge"/>.
      </para>
     </step>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -77,7 +77,7 @@
       directory.
      </para>
      <para>
-      Configure, enable and start <command>munge</command> on the control and
+      Configure, enable, and start <command>munge</command> on the control and
       compute nodes, as described in <xref linkend="sec-remote-munge"/>.
      </para>
     </step>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -1005,33 +1005,33 @@ success!</screen>
        <keycombo><keycap function="control"/><keycap>C</keycap></keycombo>).
       </para>
       <para>
-       When using a backup <literal>slurmdbd</literal>, the conversion needs to be performed
-       on the primary. The backup will not start until the conversion has
-       taken place.
+       When using a backup <literal>slurmdbd</literal>, the conversion needs to
+       be performed on the primary. The backup will not start until the
+       conversion has taken place.
       </para>
      </step>
      <step>
       <para>
-       Before restarting the service deprecated configuration options should
-       may be removed or replaced. Check the list below for a list of
-       deprecated options. Once this has been completed, restart slurmdbd.
+       Before restarting the service, you should remove or replace any
+       deprecated configuration options. Check the list of deprecated options
+       below. Once this has been completed, restart <command>slurmdbd</command>:
       </para>
 <screen>&prompt;systemctl start slurmdbd</screen>
       <note>
        <title>No daemonization during rebuild</title>
        <para>
-        During the rebuild of slurmdbd the database daemon does not daemonize.
+        During the rebuild of slurmdbd, the database daemon does not daemonize.
        </para>
       </note>
       <note>
        <title>Convert primary slurmbd first</title>
        <para>
         If a backup database daemon is used, the primary one needs to be
-        converted first. The backup will not start until this has happend.
+        converted first. The backup will not start until this has happened.
        </para>
       </note>
       <para>
-       Only after the conversion has been completed the backup will start.
+       Only after the conversion has been completed will the backup start.
       </para>
      </step>
     </substeps>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -810,7 +810,7 @@ Description="subgroup" Organization=bavaria</screen>
   To upgrade Slurm subpackages, use the analogous commands.
  </para>
  <para>
-  In addition to the <quote>the major version rule</quote> mentioned at the
+  In addition to the <quote>three major-version rule</quote> mentioned at the
   beginning of this section, obey the following rules regarding the order of
   updates:
  </para>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -19,17 +19,18 @@
    </para>
 
    <para>
-    The mandatory components of <emphasis>Slurm</emphasis> are the control
-    daemon <emphasis>slurmctld</emphasis> taking care of job scheduling, and the
-    slurm daemon <emphasis>slurmd</emphasis> responsible for launching compute
-    jobs. Subsequently, nodes running the control daemon are called master nodes
-    and nodes running the <emphasis>slurmd</emphasis> are called compute nodes.
+    The mandatory components of Slurm are the control daemon
+    <emphasis>slurmctld</emphasis>, which takes care of job scheduling, and the
+    slurm daemon <emphasis>slurmd</emphasis>, responsible for launching compute
+    jobs. Subsequently, nodes running <command>slurmctld</command> are called
+    <emphasis>master nodes</emphasis> and nodes running <command>slurmd</command>
+    are called <emphasis>compute nodes</emphasis>.
    </para>
 
    <para>
     Additional components are a secondary <emphasis>slurmctld</emphasis> acting
     as standby server for a failover, and the slurm database daemon
-    <emphasis>slurmdbd</emphasis> which stores the job history and user
+    <emphasis>slurmdbd</emphasis>, which stores the job history and user
     hierarchy.
    </para>
   </abstract>
@@ -42,8 +43,8 @@
   <title>Slurm — utility for HPC workload management</title>
 
   <para>
-   For a minimal setup of <emphasis>Slurm</emphasis> with a control node and
-   multiple compute nodes, follow these instructions:
+   For a minimal setup of Slurm with a control node and multiple compute nodes,
+   follow these instructions:
   </para>
 
   <sect2 xml:id="sec-slurm-minimal">
@@ -51,7 +52,7 @@
    <important>
     <title>Make sure of consistent UIDs and GIDs for Slurm's accounts</title>
     <para>
-     For security reasons, <emphasis>Slurm</emphasis> does not run as the user
+     For security reasons, Slurm does not run as the user 
      <systemitem class="username">root</systemitem> but under its own user. It
      is important that the user <systemitem class="username">slurm</systemitem>
      has the same UID/GID across all nodes of the cluster.
@@ -112,7 +113,7 @@
        <para>
         In order to define the compute nodes, add:
        </para>
-<screen>NodeName=<replaceable>NODE_LIST</replaceable>  State=UNKNOWN</screen>
+<screen>NodeName=<replaceable>NODE_LIST</replaceable> State=UNKNOWN</screen>
        <para>
         where the actual parameters like <literal>CPUs</literal> for compute
         node can be obtained by running the following command on the compute
@@ -120,7 +121,7 @@
        </para>
 <screen>slurmd -C</screen>
        <para>
-        Additionally the line
+        Additionally, the line
        </para>
 <screen>PartitionName=normal Nodes=<replaceable>NODE_LIST</replaceable> \
   Default=YES MaxTime=24:00:00 State=UP</screen>
@@ -158,7 +159,7 @@
       <systemitem class="daemon">slurmd</systemitem>:
      </para>
 <screen>systemctl start slurmd.service
-systemctl enable slurmd.service</screen>
+ systemctl enable slurmd.service</screen>
      <para>
       The last line causes <systemitem class="daemon">slurmd</systemitem> to be
       started on every boot automatically.
@@ -184,22 +185,22 @@ normal*      up 1-00:00:00      2   idle sle15sp2-node[1-2]
     </step>
     <step>
      <para>
-      Now the slurm installation can be tested by running:
+      Now the Slurm installation can be tested by running:
      </para>
 <screen>srun sleep 30</screen>
      <para>
-      This will try to immediatelly run the <command>sleep</command> on a free
+      This will try to immediately run the <command>sleep</command> on a free
       compute node. In another shell you can now
       <footnote>
        <para>
         at least within 30 seconds
        </para>
       </footnote>
-      run the command
+      run the command:
      </para>
 <screen>squeue</screen>
      <para>
-      It which will show you the running compute job in an output like
+      It will show you the running compute job in an output like this:
      </para>
 <screen>
     JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
@@ -233,12 +234,13 @@ sbatch sleeper.sh
   </sect2>
 
   <sect2 xml:id="sec-slurm-slurmdbd">
-   <title>Install slurm database</title>
+   <title>Install Slurm database</title>
    <para>
-    With the minimal installation, slurm will only store pending and running
+    With the minimal installation, Slurm will only store pending and running
     jobs. In order to store to finished and failed job data, the storage plugin
-    has to be installed and enabled. Additionally, so-called completely fair
-    scheduling can be enabled, which replaces the FIFO
+    has to be installed and enabled. Additionally, so-called
+    <emphasis>completely fair scheduling</emphasis> can be enabled, which
+    replaces FIFO
     <footnote>
      <para>
       <emphasis>f</emphasis>irst <emphasis>i</emphasis>n
@@ -249,8 +251,8 @@ sbatch sleeper.sh
     dependence of the job which a user has run in the history.
    </para>
    <para>
-    The slurm database has two components: the <literal>slurmdbd</literal>
-    daemon itself, and a MySQL database, where <literal>mariab</literal> is
+    The Slurm database has two components: the <literal>slurmdbd</literal>
+    daemon itself, and a MySQL database, where MariaDB is
     recommended. The database can be on the same
     node which runs <literal>slurmdbd</literal> or another node. For this
     simple setup, all these services run on the same node.
@@ -286,7 +288,7 @@ systemctl enable mariadb</screen>
     </step>
     <step xml:id="sec-sum-sqldb">
      <para>
-      In this step, the database and the user for the slurm database have to be
+      In this step, the database and the user for the Slurm database have to be
       created. This is done by connecting to the SQL database, for example with
       the command <command>mysql -u root -p</command>. After a successful
       connection, the database and the creation of a secure password
@@ -296,7 +298,7 @@ systemctl enable mariadb</screen>
         create a secure random password
        </para>
       </footnote>
-      , the slurm user and the database are created with the commands
+      , the Slurm user and the database are created with the commands
      </para>
 <screen>
 create user 'slurm'@'localhost' identified by 'password';
@@ -315,9 +317,9 @@ create database slurm_acct_db;</screen>
      </para>
 <screen>StoragePass=password</screen>
      <para>
-      to the password which you use in <xref linkend="sec-sum-sqldb"/>. When
-      another location or user for the SQL database was chosen, you also need
-      to modify the following entries:
+      to the password which you used in <xref linkend="sec-sum-sqldb"/>. If you
+      chose another location or user for the SQL database, you also need to
+      modify the following entries:
      </para>
 <screen>StorageUser=slurm
 DbdAddr=localhost
@@ -357,12 +359,11 @@ AccountingStorageHost=localhost</screen>
     </step>
     <step performance="optional">
      <para>
-      By default, <literal>slurm</literal> does not take any group membership
-      into account and it is not possible to map the system groups to
-      <literal>slurm</literal>. Group creation and membership have to be
-      managed via the command line tool <command>sacctmgr</command>. It is also
-      possible to have a group hierarchy, and users can be part of several
-      groups.
+      By default, Slurm does not take any group membership into account, and it
+      is not possible to map the system groups to Slurm. Group creation and
+      membership have to be managed via the command line tool
+      <command>sacctmgr</command>. It is also possible to have a group
+      hierarchy, and users can be part of several groups.
      </para>
      <para>
       To create an umbrella group <literal>bavaria</literal> for two subgroups
@@ -388,9 +389,9 @@ Description="subgroup" Organization=bavaria</screen>
    <title>scontrol</title>
    <para>
     The command <command>scontrol</command> is used to show and update the
-    entities of <literal>slurm</literal>, such as the state of the compute nodes
-    or compute jobs. It can also be used to reboot or to propagate configuration
-    changes to the compute nodes.
+    entities of Slurm, such as the state of the compute nodes or compute jobs.
+    It can also be used to reboot or to propagate configuration changes to the
+    compute nodes.
    </para>
    <para>
     Useful options to this command are <literal>--details</literal>, which will
@@ -468,8 +469,9 @@ Description="subgroup" Organization=bavaria</screen>
         <term>jobid=<replaceable>JOBID</replaceable><replaceable>REQUIREMENT</replaceable>=<replaceable>VALUE</replaceable></term>
         <listitem>
          <para>
-          will update the given requirement like <literal>NumNodes</literal>
-          with a new value. This command can also be executed as normal user.
+          will update the given requirement, such as
+          <literal>NumNodes</literal>, with a new value. This command can also
+          be executed as a normal user.
          </para>
         </listitem>
        </varlistentry>
@@ -480,7 +482,7 @@ Description="subgroup" Organization=bavaria</screen>
      <term>reconfigure</term>
      <listitem>
       <para>
-       will trigger a reload of the configuration
+       will trigger a reload of the configuration file
        <filename>slurm.conf</filename> on all compute nodes.
       </para>
      </listitem>
@@ -494,9 +496,9 @@ Description="subgroup" Organization=bavaria</screen>
        have to be set in <filename>slurm.conf</filename> to use this command.
       </para>
       <para>
-       When the reboot of a compute node takes more than 60s, you set set an
-       higher value for the parameter like <literal>ResumeTimeout=300</literal>
-       in <filename>slurm.conf</filename>.
+       When the reboot of a compute node takes more than 60 seconds, you can set
+       a higher value for the parameter, such as
+       <literal>ResumeTimeout=300</literal> in <filename>slurm.conf</filename>.
       </para>
      </listitem>
     </varlistentry>
@@ -504,7 +506,7 @@ Description="subgroup" Organization=bavaria</screen>
      <term><command>sacctmgr</command></term>
      <listitem>
       <para>
-       is used for job accounting within slurm. The service
+       is used for job accounting within Slurm. The service
        <literal>slurmdbd</literal> has to be setup in order to use this
        command. Follow the steps in <xref linkend="sec-sum-sqldb"/> to setup
        <literal>slurmdbd</literal>.
@@ -516,8 +518,8 @@ Description="subgroup" Organization=bavaria</screen>
      <listitem>
       <para>
        retrieves information about the state of the compute nodes, and can be
-       used for a fast overview of the cluster health. The following comman
-       line switches are available:
+       used for a fast overview of the cluster health. The following
+       command-line switches are available:
       </para>
       <variablelist>
        <varlistentry>
@@ -596,7 +598,7 @@ Description="subgroup" Organization=bavaria</screen>
           only jobs after starttime will be showed. It also possible to have
           just <replaceable>MM/DD</replaceable> or
           <replaceable>HH:MM</replaceable>. If no time is given, defaults to
-          <literal>00:00</literal>, what means that only jobs from this day are
+          <literal>00:00</literal>, which means that only jobs from today are
           shown.
          </para>
         </listitem>
@@ -636,11 +638,13 @@ Description="subgroup" Organization=bavaria</screen>
        these commands are used to schedule a compute job, which is a batch script
        for the <command>sbatch</command> command, a interactive session for
        <command>salloc</command>, and a binary for <command>srun</command>.
-       Please note that only <command>sbatch</command> will place the submitted
-       job script into the queue if it can not be scheduled immediately.
       </para>
       <para>
-       Some frequently-used options for this commands are:
+       Note that if the job can not be scheduled immediately, only
+       <command>sbatch</command> will place it into the queue.
+      </para>
+      <para>
+       Some frequently-used options for these commands are:
       </para>
       <variablelist>
        <varlistentry>
@@ -667,9 +671,9 @@ Description="subgroup" Organization=bavaria</screen>
          <para>
           specifies the maximal clocktime (runtime) after which a job is
           killed. The format of <replaceable>TIME</replaceable> is either
-          seconds or <replaceable>[HH:]MM:SS</replaceable>. No to be confused
-          with the walltime which is the <literal>clocktime &#215;
-          threads</literal>.
+          seconds or <replaceable>[HH:]MM:SS</replaceable>. Not to be confused
+          with <command>walltime</command>, which is 
+          <literal>clocktime &times; threads</literal>.
          </para>
         </listitem>
        </varlistentry>
@@ -677,11 +681,12 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--signal <replaceable>[B:]NUMBER[@TIME]</replaceable></command></term>
         <listitem>
          <para>
-          selects the signal with the <replaceable>NUMBER</replaceable> to be
-          sent 60 seconds before job end if not <replaceable>TIME</replaceable>
-          is specified. The signal will be sent to every process on every node.
-          When only a signal should be sent to the controlling batch job, you
-          have to specify the <command>B:</command> flag.
+          means that the signal specified by <replaceable>NUMBER</replaceable>
+          will be sent, 60 seconds before the end of the job unless
+          <replaceable>TIME</replaceable>
+          was specified. The signal will be sent to every process on every node.
+          If a signal should only be sent to the controlling batch job, you
+          must specify the <command>B:</command> flag.
          </para>
         </listitem>
        </varlistentry>
@@ -717,8 +722,9 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--gres=<replaceable>GRES</replaceable></command></term>
         <listitem>
          <para>
-          run job only on node with the give <replaceable>GRES</replaceable>
-          available. A generic resource is a GPU for example.
+          run a job only on nodes with the specified <emphasis>generic
+          resource</emphasis>, for example a GPU, specified by the value of
+          <replaceable>GRES</replaceable>.
          </para>
         </listitem>
        </varlistentry>
@@ -726,9 +732,11 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--licenses=<replaceable>NAME[:COUNT]</replaceable></command></term>
         <listitem>
          <para>
-          the job needs the number <replaceable>COUNT</replaceable> of licenses
-          with the name <replaceable>NAME</replaceable>. In opposite to a gres,
-          a license is not tight to a compute, but is a cluster wide variable.
+          the job must have the number specified in
+          <replaceable>COUNT</replaceable> of licenses with the name
+          <replaceable>NAME</replaceable>. A license is the opposite of a
+          generic resource: it is not tied to a computer, but is a cluster-wide
+          variable.
          </para>
         </listitem>
        </varlistentry>
@@ -737,11 +745,11 @@ Description="subgroup" Organization=bavaria</screen>
         <listitem>
          <para>
           sets the real memory <replaceable>MEMORY</replaceable> needed by a
-          job per node, memory control has to be enabled in order to use this
-          option. The default unit for <replaceable>MEMORY</replaceable>, but
-          also <literal>K</literal> for kilobyte, <literal>M</literal> for
-          megabyte, <literal>G</literal> for gigabyte and <literal>T</literal>
-          for terabyte can be used.
+          job per node. To use this option, memory control must be enabled. The
+          default unit for the <replaceable>MEMORY</replaceable> value is
+          megabytes, but you can also use <literal>K</literal> for kilobyte,
+          <literal>M</literal> for megabyte, <literal>G</literal> for gigabyte,
+          and <literal>T</literal> for terabyte.
          </para>
         </listitem>
        </varlistentry>
@@ -749,8 +757,8 @@ Description="subgroup" Organization=bavaria</screen>
         <term><command>--mem-per-cpu=<replaceable>MEMORY</replaceable></command></term>
         <listitem>
          <para>
-          same options as for <command>--mem</command>, but defines memory per
-          used CPU.
+          This takes the same options as <command>--mem</command>, but defines
+          memory on a per-CPU basis rather than a per-node basis.
          </para>
         </listitem>
        </varlistentry>
@@ -799,7 +807,7 @@ Description="subgroup" Organization=bavaria</screen>
  </para>
  <screen>zypper install --force-resolution slurm_18_08</screen>
  <para>
-  To upgrade Slurm subpackages, proceed analogously.
+  To upgrade Slurm subpackages, use the analogous commands.
  </para>
  <para>
   In addition to the <quote>the major version rule</quote> mentioned at the
@@ -850,461 +858,365 @@ Description="subgroup" Organization=bavaria</screen>
   It should be noted that a new major version of Slurm introduces a new version
   of <literal>libslurm</literal>. Older versions of this library might no longer
   work with an upgraded Slurm. For all &slea; software depending on
-  <literal>libslurm </literal> an upgrade will be provided. Any locally
-  developed Slurm modules or tools may require modification and/or
+  <literal>libslurm </literal>, an upgrade will be provided. Any
+  locally-developed Slurm modules or tools may require modification and/or
   recompilation.
  </para>
- <sect2 xml:id="sec-slurm-upgrade-workflow">
-  <title>Upgrade workflow</title>
-  <para>
-   For this workflow it is assumed that munge authentication is used and that
-   <literal>pdsh</literal>, the pdsh Slurm plugin and mrsh are usable to access
-   the all machines of the cluster (that is <literal>mrshd</literal> is running
-   on all nodes in the cluster).
-  </para>
-  <para>
-   If this is not the case, install <literal>pdsh</literal>:
-  </para>
-<screen>&prompt;zypper in pdsh-slurm</screen>
-  <para>
-   if <literal>mrsh</literal> is not used in the cluster, the
-   <literal>ssh</literal> back-end for <literal>pdsh</literal> may be used as
-   well for this, simply replace the option <literal>-R mrsh</literal> by
-   <literal>-R ssh</literal>in the <literal>pdsh</literal>commands below. This
-   is less scalable and you may run out of usable ports.
-  </para>
-  <procedure xml:id="pro-slurm-upgrade-workflow">
-   <title>Upgrading Slurm</title>
-   <step>
-    <para>
-     <emphasis role="bold">Upgrade slurmdbd Database Daemon</emphasis>
-    </para>
-    <para>
-     If the database daemon <literal>slurmdbd</literal> is used, it must be
-     upgraded first. Care must be taken if the same database is used for
-     multiple clusters. The database needs to be updated before any cluster
-     is updated.
-    </para>
-    <para>
-     It should be noted that when upgrading <literal>slurmdbd</literal>,
-     a conversion of the database will take place when the new version of
-     <literal>slurmdbd</literal> is started for the first time. If the
-     database is big the conversion will take several 10s of minutes.
-     During this time, the database is not accessible.
-    </para>
-    <para>
-     It is highly recommended to create a backup of the database in case an
-     error occurs during the upgrade process or afterwards: without a backup
-     all accounting data collected in the database may be lost if an error
-     occurs or the upgrade must be rolled back for some reason. A database
-     converted to a newer version cannot be converted back to an older one and
-     older versions of <literal>slurmdbd</literal> will not recognize the
-     newer formats. To backup and upgrade <literal>slurmdbd</literal> you may
-     follow this procedure:
-    </para>
-    <substeps>
-     <step>
-      <para>
-       Stop the <literal>slurmdbd</literal> service:
-      </para>
-      <screen>&prompt;rcslurmdbd stop</screen>
-      <para>
-       Make sure that <literal>slurmdbd</literal> is not running anymore:
-      </para>
-      <screen>&prompt;rcslurmdbd status</screen>
-      <para>
-       It should be noted that <literal>slurmctld</literal> might remain running
-       while the database daemon is down. While it is down, requests intended
-       for <literal>slurmdbd</literal> are queued internally. The DBD Agent
-       Queue size is limited, however, and should therefore be monitored with
-       <literal>sdiag</literal>.
-      </para>
-     </step>
-     <step>
-      <para>
-       Create a backup of the slurm_acct_db database:
-      </para>
-      <screen>&prompt;mysqldump -p slurm_acct_db &gt; slurm_acct_db.sql</screen>
-      <para>
-       If needed, this can be restored calling:
-      </para>
-      <screen>&prompt;mysql -p slurm_acct_db &lt; slurm_acct_db.sql</screen>
-     </step>
-     <step>
-      <para>
-       In preparation of the conversion, make sure, the variable
-       <literal>innodb_buffer_size</literal> is set to a value &gt;= 128 Mb:
-      </para>
-      <para>
-       On the database server, run:
-      </para>
-<screen>&prompt;echo  'SELECT @@innodb_buffer_pool_size/1024/1024;' | \
+  <sect2 xml:id="sec-slurm-upgrade-workflow">
+   <title>Upgrade workflow</title>
+   <para> For this workflow, we assume that MUNGE authentication is used and
+    that <literal>pdsh</literal>, the pdsh Slurm plugin and mrsh are usable to
+    access the all machines of the cluster (that is <literal>mrshd</literal> is
+    running on all nodes in the cluster). </para>
+   <para> If this is not the case, install <literal>pdsh</literal>: </para>
+   <screen>&prompt;zypper in pdsh-slurm</screen>
+   <para> if <literal>mrsh</literal> is not used in the cluster, the
+     <literal>ssh</literal> back-end for <literal>pdsh</literal> may be used as
+    well for this, simply replace the option <literal>-R mrsh</literal> by
+     <literal>-R ssh</literal>in the <literal>pdsh</literal>commands below. This
+    is less scalable and you may run out of usable ports. </para>
+   <procedure xml:id="pro-slurm-upgrade-workflow">
+    <title>Upgrading Slurm</title>
+    <step>
+     <para>
+      <emphasis role="bold">Upgrade slurmdbd Database Daemon</emphasis>
+     </para>
+     <para> If the database daemon <literal>slurmdbd</literal> is used, it must
+      be upgraded first. Care must be taken if the same database is used for
+      multiple clusters. The database needs to be updated before any cluster is
+      updated. </para>
+     <para> It should be noted that when upgrading <literal>slurmdbd</literal>,
+      a conversion of the database will take place when the new version of
+       <literal>slurmdbd</literal> is started for the first time. If the
+      database is big the conversion will take several tens of minutes. During
+      this time, the database will be inaccessible. </para>
+     <para> It is highly recommended to create a backup of the database in case
+      an error occurs during the upgrade process or afterwards: without a backup
+      all accounting data collected in the database may be lost if an error
+      occurs or the upgrade must be rolled back for some reason. A database
+      converted to a newer version cannot be converted back to an older one and
+      older versions of <literal>slurmdbd</literal> will not recognize the newer
+      formats. To backup and upgrade <literal>slurmdbd</literal> you may follow
+      this procedure: </para>
+     <substeps>
+      <step>
+       <para> Stop the <literal>slurmdbd</literal> service: </para>
+       <screen>&prompt;rcslurmdbd stop</screen>
+
+       <para> Make sure that <literal>slurmdbd</literal> is not running anymore: </para>
+       <screen>&prompt;rcslurmdbd status</screen>
+       <para> It should be noted that <literal>slurmctld</literal> might remain
+        running while the database daemon is down. While it is down, requests
+        intended for <literal>slurmdbd</literal> are queued internally. The DBD
+        Agent Queue size is limited, however, and should therefore be monitored
+        with <literal>sdiag</literal>. </para>
+      </step>
+      <step>
+       <para> Create a backup of the slurm_acct_db database: </para>
+       <screen>&prompt;mysqldump -p slurm_acct_db &gt; slurm_acct_db.sql</screen>
+       <para> If needed, this can be restored calling: </para>
+       <screen>&prompt;mysql -p slurm_acct_db &lt; slurm_acct_db.sql</screen>
+      </step>
+      <step>
+       <para> In preparation of the conversion, make sure, the variable
+         <literal>innodb_buffer_size</literal> is set to a value &gt;=
+        128 Mb: </para>
+       <para> On the database server, run: </para>
+       <screen>&prompt;echo  'SELECT @@innodb_buffer_pool_size/1024/1024;' | \
   mysql --password --batch</screen>
-      <para>
-       If the size is less than 128Mb it can be changed on the fly for the
-       current session (on <literal>mariadb</literal>)
-      </para>
-<screen>&prompt;echo 'set GLOBAL innodb_buffer_pool_size = 134217728;' | \
+       <para> If the size is less than 128&nbsp;MB, it can be changed on the
+        fly for the current session (on <literal>mariadb</literal>) </para>
+       <screen>&prompt;echo 'set GLOBAL innodb_buffer_pool_size = 134217728;' | \
   mysql --password --batch</screen>
-      <para>
-       or permanently by editing /etc/my.cnf and set it to 128Mb then restart
-       the database:
-      </para>
-      <screen>&prompt;rcmysql restart</screen>
-     </step>
-     <step xml:id="step-slurm-upgrade-workflow-install-slurmdbd">
-      <para>
-       Install the upgrade of <literal>slurmdbd</literal>:
-      </para>
-<screen>zypper install --force-resolution slurm_<replaceable>version</replaceable>-slurmdbd</screen>
-      <note>
-       <title>Update MariaDB separately</title>
+       <para> or permanently by editing <filename>/etc/my.cnf</filename>,
+        setting it to 128&nbsp;MB then restarting the database: </para>
+       <screen>&prompt;rcmysql restart</screen>
+      </step>
+      <step xml:id="step-slurm-upgrade-workflow-install-slurmdbd">
+       <para> Install the upgrade of <literal>slurmdbd</literal>: </para>
+       <screen>zypper install --force-resolution slurm_<replaceable>version</replaceable>-slurmdbd</screen>
+       <note>
+        <title>Update MariaDB separately</title>
+        <para> If you also need to update <literal>mariadb</literal>, it is
+         recommended to perform this step separately,
+          <emphasis>before</emphasis> performing step <xref
+          linkend="step-slurm-upgrade-workflow-install-slurmdbd"/>. </para>
+       </note>
+       <substeps>
+        <step>
+         <para> Upgrade MariaDB: </para>
+         <screen>&prompt;zypper update mariadb</screen>
+        </step>
+        <step>
+         <para> Run the conversion of the database tables to the new version of
+          MariaDB: </para>
+         <screen>mysql_upgrade --user=root --password=<replaceable>root_db_password</replaceable>;</screen>
+        </step>
+       </substeps>
+      </step>
+      <step>
        <para>
-        If you also need to update <literal>mariadb</literal>, it is
-        recommended to perform this step separately,
-        <emphasis>before</emphasis> performing step
-        <xref linkend="step-slurm-upgrade-workflow-install-slurmdbd"/>.
+        <emphasis role="bold">Rebuild database</emphasis>
        </para>
-      </note>
-      <substeps>
-       <step>
-        <para>
-         Upgrade MariaDB:
-        </para>
-        <screen>&prompt;zypper update mariadb</screen>
-       </step>
-       <step>
-        <para>
-         Run the conversion of the database tables to the new version of
-         MariaDB:
-        </para>
-        <screen>mysql_upgrade --user=root --password=<replaceable>root_db_password</replaceable>;</screen>
-       </step>
-      </substeps>
-     </step>
-     <step>
-      <para>
-       <emphasis role="bold">Rebuild database</emphasis>
-      </para>
-      <para>
-       Since a conversion may take a considerable amount of time, the systemd
-       service may run into a timeout during the conversion. Thus we recommend
-       to perform the migration manually by running
-       <literal>slurmdbd</literal> from the command line in the foreground:
-      </para>
-<screen>&prompt;/usr/sbin/slurmdbd -D -v</screen>
-      <para>
-       Once you see the message:
-      </para>
-<screen>Conversion done:
+       <para> Since a conversion may take a considerable amount of time, the
+        systemd service may run into a timeout during the conversion. Thus we
+        recommend performing the migration manually, by running
+         <literal>slurmdbd</literal> from the command line in the foreground: </para>
+       <screen>&prompt;/usr/sbin/slurmdbd -D -v</screen>
+       <para> Once you see the message: </para>
+       <screen>Conversion done:
 success!</screen>
-      <para>
-       <literal>slurmdbd</literal> may be shut down with signal
-       <literal>SIGTERM</literal> (that is, by pressing
-       <keycombo><keycap function="control"/><keycap>C</keycap></keycombo>).
-      </para>
-      <para>
-       When using a backup <literal>slurmdbd</literal>, the conversion needs to
-       be performed on the primary. The backup will not start until the
-       conversion has taken place.
-      </para>
-     </step>
-     <step>
-      <para>
-       Before restarting the service, you should remove or replace any
-       deprecated configuration options. Check the list of deprecated options
-       below. Once this has been completed, restart <command>slurmdbd</command>:
-      </para>
-<screen>&prompt;systemctl start slurmdbd</screen>
-      <note>
-       <title>No daemonization during rebuild</title>
        <para>
-        During the rebuild of slurmdbd, the database daemon does not daemonize.
-       </para>
-      </note>
-      <note>
-       <title>Convert primary slurmbd first</title>
-       <para>
-        If a backup database daemon is used, the primary one needs to be
-        converted first. The backup will not start until this has happened.
-       </para>
-      </note>
-      <para>
-       Only after the conversion has been completed will the backup start.
-      </para>
-     </step>
-    </substeps>
-   </step>
-   <step>
-    <para>
-     <emphasis role="bold">Update slurmctld and slurmd</emphasis>
-    </para>
-    <para>
-     Once the Slurm database has been updated, the
-     <literal>slurmctld</literal> and <literal>slurmd</literal>
-     instances may be updated. It is recommended to update the head and compute
-     nodes all in a single pass. If this is not feasible, the compute nodes
-     (<literal>slurmd</literal>) may be updated on a node-by-node basis, this
-     however requires that the master nodes (<literal>slurmctld</literal>) have
-     been updated successfully.
-    </para>
-    <substeps>
-     <step>
-      <para>
-       <emphasis role="bold">Back up the
-       <literal>slurmctld</literal>/<literal>slurmd</literal>
-       configuration</emphasis>
-      </para>
-      <para>
-       It is advisable to create a backup copy of the Slurm configuration
-       before starting the upgrade process. Since the configuration file
-       <literal>/etc/slurm/slurm.conf</literal> should be identical across the
-       entire cluster, it is sufficient to do so on the master controller node.
-      </para>
-     </step>
-     <step xml:id="st-slurm-timeout">
-      <para>
-       <emphasis role="bold">Increase Timeouts</emphasis>
-      </para>
-      <para>
-       Set <literal>SlurmdTimeout</literal> and
-       <literal>SlurmctldTimeout</literal> in
-       <literal>/etc/slurm/slurm.conf</literal> to sufficiently high values to
-       avoid timeouts while <literal>slurmctld</literal> and
-       <literal>slurmd</literal> are down. We recommend at least 60 minutes,
-       more on larger clusters.
-      </para>
-      <substeps>
-       <step>
-        <para>
-         Edit <literal>/etc/slurm/slurm.conf</literal> on the master controller
-         node and set the values for this variable to at least 3600 (1h).
+        <literal>slurmdbd</literal> may be shut down with signal
+         <literal>SIGTERM</literal> (that is, by pressing <keycombo>
+         <keycap function="control"/>
+         <keycap>C</keycap>
+        </keycombo>). </para>
+       <para> When using a backup <literal>slurmdbd</literal>, the conversion
+        needs to be performed on the primary. The backup will start after the
+        conversion has completed. </para>
+      </step>
+      <step>
+       <para> Before restarting the service, you should remove or replace any
+        deprecated configuration options. Check the list of deprecated options
+        below. Once this has been completed, restart
+        <command>slurmdbd</command>: </para>
+       <screen>&prompt;systemctl start slurmdbd</screen>
+       <note>
+        <title>No daemonization during rebuild</title>
+        <para> During the rebuild of <literal>slurmdb</literal>, the database
+         daemon does not daemonize. </para>
+       </note>
+       <note>
+        <title>Convert primary slurmdb first</title>
+        <para> If a backup database daemon is used, the primary one needs to be
+         converted first. The backup will not start until this has happened.
         </para>
-<screen>SlurmctldTimeout=3600
+       </note>
+      </step>
+     </substeps>
+    </step>
+    <step>
+     <para>
+      <emphasis role="bold">Update <literal>slurmctld</literal> and
+        <literal>slurmd</literal></emphasis>
+     </para>
+     <para> Once the Slurm database has been updated, the
+       <literal>slurmctld</literal> and <literal>slurmd</literal> instances may
+      be updated. It is recommended to update the head and compute nodes all in
+      a single pass. If this is not feasible, the compute nodes
+       (<literal>slurmd</literal>) may be updated on a node-by-node basis.
+      However, this requires that the master nodes
+      (<literal>slurmctld</literal>) have been updated successfully. </para>
+     <substeps>
+      <step>
+       <para>
+        <emphasis role="bold">Back up the
+          <literal>slurmctld</literal>/<literal>slurmd</literal>
+         configuration</emphasis>
+       </para>
+       <para> It is advisable to create a backup copy of the Slurm configuration
+        before starting the upgrade process. Since the configuration file
+         <filename>/etc/slurm/slurm.conf</filename> should be identical across
+        the entire cluster, it is sufficient to do so on the master controller
+        node. </para>
+      </step>
+      <step xml:id="st-slurm-timeout">
+       <para>
+        <emphasis role="bold">Increase Timeouts</emphasis>
+       </para>
+       <para> Set <literal>SlurmdTimeout</literal> and
+         <literal>SlurmctldTimeout</literal> in
+         <filename>/etc/slurm/slurm.conf</filename> to sufficiently high values
+        to avoid timeouts while <literal>slurmctld</literal> and
+         <literal>slurmd</literal> are down. We recommend at least 60 minutes,
+        and more on larger clusters. </para>
+       <substeps>
+        <step>
+         <para> Edit <filename>/etc/slurm/slurm.conf</filename> on the master
+          controller node and set the values for this variable to at least 3600
+          (one hour). </para>
+         <screen>SlurmctldTimeout=3600
 SlurmdTimeout=3600</screen>
-       </step>
-       <step>
-        <para>
-         Copy <literal>/etc/slurm/slurm.conf</literal> to all nodes. If
-         <literal>munge</literal> authentication is used in the cluster as
-         recommended.
-        </para>
-        <substeps>
-         <step>
-          <para>
-           Obtain the list of partitions in <filename>/etc/slurm/slurm.conf</filename>.
-          </para>
-         </step>
-         <step>
-          <para>
-           Execute:
-          </para>
-<screen>&prompt;cp /etc/slurm/slurm.conf /etc/slurm/slurm.conf.update
+        </step>
+        <step>
+         <para> Copy <filename>/etc/slurm/slurm.conf</filename> to all nodes, if
+          MUNGE authentication is used in the cluster as recommended. </para>
+         <substeps>
+          <step>
+           <para> Obtain the list of partitions in
+             <filename>/etc/slurm/slurm.conf</filename>. </para>
+          </step>
+          <step>
+           <para> Execute: </para>
+           <screen>&prompt;cp /etc/slurm/slurm.conf /etc/slurm/slurm.conf.update
 &prompt;sudo -u slurm /bin/bash -c 'cat /etc/slurm/slurm.conf.update \
   | pdsh -R mrsh -P <replaceable>partitions</replaceable> \
   "cat > /etc/slurm/slurm.conf"'
 &prompt;rm /etc/slurm/slurm.conf.update
 &prompt;scontrol reconfigure
 </screen>
-         </step>
-         <step>
-          <para>
-           Verify that the reconfiguration took effect:
-          </para>
-          <screen>&prompt;scontrol show config | grep Timeout</screen>
-         </step>
-        </substeps>
-       </step>
-      </substeps>
-     </step>
-     <step>
-      <para>
-       <emphasis role="bold">Shut down any running <literal>slurmctld</literal>
-       instances</emphasis>
-      </para>
-      <substeps>
-       <step>
-        <para>
-         If applicable, shut down any backup controllers on the backup head
-         nodes:
-        </para>
-        <screen>&prompt_backup;systemctl stop slurmctld</screen>
-       </step>
-       <step>
-        <para>
-         Shut down the master controller:
-        </para>
-<screen>&prompt_master;systemctl stop slurmctld</screen>
-       </step>
-      </substeps>
-     </step>
-     <step>
-      <para>
-       <emphasis role="bold">Back up the <literal>slurmctld</literal> state files</emphasis>
-      </para>
-      <para>
-       Also, it should be noted, that <literal>slurmctld</literal> maintains
-       state information that is persistent. Almost every major version
-       involves changes to the <literal>slurmctld</literal> state files.
-       This state information will be upgraded as well if the upgrade remains
-       within the supported version range and no data will be lost.
-      </para>
-      <para>
-       However, if a downgrade should become necessary, state information
-       from newer versions will not be recognized by an older version of
-       <literal>slurmctld</literal> and thus will be discarded, resulting in a loss of all
-       running and pending jobs. Thus it is useful to back up the old state
-       in case an update needs to be rolled back.
-      </para>
-      <substeps>
-       <step>
-        <para>
-         Determine the <literal>StateSaveLocation</literal> directory:
-        </para>
-<screen>&prompt;scontrol show config | grep StateSaveLocation</screen>
-       </step>
-       <step>
-        <para>
-         Create a backup of the content of this directory to be able to roll
-         back the update if an issue arises.
-        </para>
-        <para>
-         Should a downgrade be required make sure to restore the content of the
-         <literal>StateSaveLocation</literal> directory from this backup.
-        </para>
-       </step>
-      </substeps>
-     </step>
-     <step>
-      <para>
-       <emphasis role="bold">Shut down <literal>slurmd</literal> on the nodes</emphasis>
-      </para>
-<screen>&prompt;pdsh -R ssh -P <replaceable>partitions</replaceable> systemctl stop slurmd</screen>
-     </step>
-     <step>
-      <para>
-       <emphasis role="bold">Update <literal>slurmctld</literal> on the
-       master and backup nodes as well as <literal>slurmd</literal> on the
-       compute nodes</emphasis>
-      </para>
-      <substeps>
-       <step>
-        <para>
-         On the master/backup node(s): run:
-        </para>
-<screen>&prompt_master;zypper zypper install \
+          </step>
+          <step>
+           <para> Verify that the reconfiguration took effect: </para>
+           <screen>&prompt;scontrol show config | grep Timeout</screen>
+          </step>
+         </substeps>
+        </step>
+       </substeps>
+      </step>
+      <step>
+       <para>
+        <emphasis role="bold">Shut down any running <literal>slurmctld</literal>
+         instances</emphasis>
+       </para>
+       <substeps>
+        <step>
+         <para> If applicable, shut down any backup controllers on the backup
+          head nodes: </para>
+         <screen>&prompt_backup;systemctl stop slurmctld</screen>
+        </step>
+        <step>
+         <para> Shut down the master controller: </para>
+         <screen>&prompt_master;systemctl stop slurmctld</screen>
+        </step>
+       </substeps>
+      </step>
+      <step>
+       <para>
+        <emphasis role="bold">Back up the <literal>slurmctld</literal> state
+         files</emphasis>
+       </para>
+       <para> Also, it should be noted, that <literal>slurmctld</literal>
+        maintains state information that is persistent. Almost every major
+        version involves changes to the <literal>slurmctld</literal> state
+        files. This state information will be upgraded as well if the upgrade
+        remains within the supported version range and no data will be lost. </para>
+       <para> However, if a downgrade should become necessary, state information
+        from newer versions will not be recognized by an older version of
+         <literal>slurmctld</literal> and thus will be discarded, resulting in a
+        loss of all running and pending jobs. Thus it is useful to back up the
+        old state in case an update needs to be rolled back. </para>
+       <substeps>
+        <step>
+         <para> Determine the <literal>StateSaveLocation</literal> directory: </para>
+         <screen>&prompt;scontrol show config | grep StateSaveLocation</screen>
+        </step>
+        <step>
+         <para> Create a backup of the content of this directory to be able to
+          roll back the update if an issue arises. </para>
+         <para> Should a downgrade be required make sure to restore the content
+          of the <literal>StateSaveLocation</literal> directory from this
+          backup. </para>
+        </step>
+       </substeps>
+      </step>
+      <step>
+       <para>
+        <emphasis role="bold">Shut down <literal>slurmd</literal> on the
+         nodes</emphasis>
+       </para>
+       <screen>&prompt;pdsh -R ssh -P <replaceable>partitions</replaceable> systemctl stop slurmd</screen>
+      </step>
+      <step>
+       <para>
+        <emphasis role="bold">Update <literal>slurmctld</literal> on the master
+         and backup nodes as well as <literal>slurmd</literal> on the compute
+         nodes</emphasis>
+       </para>
+       <substeps>
+        <step>
+         <para> On the master/backup node(s): run: </para>
+         <screen>&prompt_master;zypper zypper install \
   --force-resolution slurm_<replaceable>version</replaceable></screen>
-       </step>
-       <step>
-        <para>
-         On the master node run:
-        </para>
-<screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
+        </step>
+        <step>
+         <para> On the master node run: </para>
+         <screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
   zypper install --force-resolution \
   slurm_<replaceable>version</replaceable>-node</screen>
-       </step>
-      </substeps>
-     </step>
-     <step>
-      <para>
-       <emphasis role="bold">Replace deprecated options</emphasis>
-      </para>
-      <para>
-       If deprecated options are to be replaced in the configuration files (see
-       list below), this may be performed before updating the services. These
-       configuration files may be distributed to all controllers and nodes of
-       the cluster by using the method as described in 3.b.bb above.
-      </para>
-      <note>
-       <title>Memory size seen by <literal>slurmd</literal> may change on update</title>
+        </step>
+       </substeps>
+      </step>
+      <step>
        <para>
-        Under certain circumstances, the amount of memory seen by
-        <literal>slurmd</literal> may change after an update. If this
-        happens, <literal>slurmctld</literal> will put the nodes
-        in a <literal>drained</literal> state. To check, whether the amount of
-        memory seem by <literal>slurmd</literal> will change after the update,
-        you may run on a single compute node:
+        <emphasis role="bold">Replace deprecated options</emphasis>
        </para>
-<screen>&prompt_node1;slurmd -C</screen>
+       <para> If deprecated options are to be replaced in the configuration
+        files (see list below), this may be performed before updating the
+        services. These configuration files may be distributed to all
+        controllers and nodes of the cluster by using the method as described in
+        3.b.bb above. </para>
+       <note>
+        <title>Memory size seen by <literal>slurmd</literal> may change on
+         update</title>
+        <para> Under certain circumstances, the amount of memory seen by
+          <literal>slurmd</literal> may change after an update. If this happens,
+          <literal>slurmctld</literal> will put the nodes in a
+          <literal>drained</literal> state. To check, whether the amount of
+         memory seem by <literal>slurmd</literal> will change after the update,
+         you may run on a single compute node: </para>
+        <screen>&prompt_node1;slurmd -C</screen>
+        <para> Compare the output with the settings in
+          <filename>slurm.conf</filename>. If required, correct the setting.
+        </para>
+       </note>
+      </step>
+      <step>
        <para>
-        Compare the output with the settings in
-        <filename>slurm.conf</filename>. If required, correct the setting.
+        <emphasis role="bold">Restart <literal>slurmd</literal> on all compute
+         nodes</emphasis>
        </para>
-      </note>
-     </step>
-     <step>
-      <para>
-       <emphasis role="bold">Restart <literal>slurmd</literal> on all compute
-       nodes</emphasis>
-      </para>
-      <para>
-       On the master controller run:
-      </para>
-<screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
+       <para> On the master controller run: </para>
+       <screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
   systemctl start slurmd</screen>
-      <para>
-       On the master, run:
-      </para>
-<screen>&prompt_master;systemctl start slurmctld</screen>
-      <para>
-       then execute the same on the backup controller(s)
-      </para>
-     </step>
-     <step>
-      <para>
-       <emphasis role="bold">Verify if the system operates properly</emphasis>
-      </para>
-      <substeps>
-       <step>
-        <para>
-         Check the status of the controller(s)
-        </para>
-        <para>
-         On the master and backup controllers, run:
-        </para>
-<screen>&prompt;systemctl status slurmctld</screen>
-       </step>
-       <step>
-        <para>
-         and verify that the services are running without errors.
-        </para>
-        <para>
-         Run:
-        </para>
-<screen>sinfo -R</screen>
-        <para>
-         to check whether there are any down, drained, failing of failed nodes
-         after restart.
-        </para>
-       </step>
-      </substeps>
-     </step>
-     <step>
-      <para>
-       <emphasis role="bold">Clean up</emphasis>
-      </para>
-      <para>
-       Restore the <literal>SlurmdTimeout</literal> and
-       <literal>SlurmctldTimeout</literal> values in
-       <literal>/etc/slurm/slurm.conf</literal> on all nodes and run
-       <literal>scontrol reconfigure</literal> (see
-       <xref linkend="st-slurm-timeout"/>).
-      </para>
-     </step>
-    </substeps>
-   </step>
-  </procedure>
-  <para>
-   A new major version of libslurm is provided with each service pack of
-   &product;. The old version will not be uninstalled on upgrade and user
-   provided applications built with an old version should continue to work if
-   the old library used is not older than the the past 2 versions. It is
-   strongly recommended to rebuild local applications using libslurm - such as
-   MPI libraries with slurm support - as early as possible. This may require to
-   update the user application as new arguments may be introduced to existing
-   functions.
-  </para>
- </sect2>
+       <para> On the master, run: </para>
+       <screen>&prompt_master;systemctl start slurmctld</screen>
+       <para> then execute the same on the backup controller(s) </para>
+      </step>
+      <step>
+       <para>
+        <emphasis role="bold">Verify if the system operates properly</emphasis>
+       </para>
+       <substeps>
+        <step>
+         <para> Check the status of the controller(s). On the master and backup
+          controllers, run: </para>
+         <screen>&prompt;systemctl status slurmctld</screen>
+        </step>
+        <step>
+         <para> and verify that the services are running without errors. </para>
+         <para> Run: </para>
+         <screen>sinfo -R</screen>
+         <para> to check whether there are any <literal>down</literal>,
+           <literal>drained</literal>, <literal>failing</literal> or
+           <literal>failed</literal> nodes after restart. </para>
+        </step>
+       </substeps>
+      </step>
+      <step>
+       <para>
+        <emphasis role="bold">Clean up</emphasis>
+       </para>
+       <para> Restore the <literal>SlurmdTimeout</literal> and
+         <literal>SlurmctldTimeout</literal> values in
+         <literal>/etc/slurm/slurm.conf</literal> on all nodes and run
+         <literal>scontrol reconfigure</literal> (see <xref
+         linkend="st-slurm-timeout"/>). </para>
+      </step>
+     </substeps>
+    </step>
+   </procedure>
+   <para> A new major version of <package>libslurm</package> is provided with
+    each service pack of &product;. The old version will not be uninstalled
+    on upgrade, and user-provided applications built with an old version should
+    continue to work if the old library used is not older than the the past two
+    versions. It is strongly recommended to rebuild local applications using
+     <literal>libslurm</literal> &mdash; such as MPI libraries with Slurm
+    support &mdash; as early as possible. This may require updating the user
+    applications, as new arguments may be introduced to existing functions.
+   </para>
+  </sect2>
  </sect1>
  
  <sect1 xml:id="sec-slurm-additional-res">
@@ -1314,13 +1226,15 @@ SlurmdTimeout=3600</screen>
    <qandaset>
     <qandaentry>
       <question>
-       <para>How do I change the state of a node from down to up?</para>
+       <para>How do I change the state of a node from <literal>down</literal> to
+        <literal>up</literal>?
+       </para>
       </question>
        <answer>
         <para>
          When the <literal>slurmd</literal> daemon on a node does not reboot in
-         the time given by the <literal>ResumeTimeout</literal> parameter, or
-         the <literal>ReturnToService</literal> was not changed in the
+         the time specified in the <literal>ResumeTimeout</literal> parameter,
+         or the <literal>ReturnToService</literal> was not changed in the
          configuration file <filename>slurm.conf</filename>, compute nodes stay
          in the <literal>down</literal> state and have to be set back to the
          <literal>up</literal> state manually. This can be done for the
@@ -1338,13 +1252,18 @@ SlurmdTimeout=3600</screen>
       </question>
       <answer>
        <para>
-        When a node is marked as <literal>down</literal>, this means that the
-        node is not reachable due to network issues or the
-        <literal>slurmd</literal> is not running. In the <literal>down</literal>
-        state, the node is reachable, but the node was rebooted unexpectedly,
-        the hardware does not match the description in
-        <filename>slurm.conf</filename>, or a healthcheck was configured with
-        the <literal>HealthCheckProgram</literal>.
+        A <literal>*</literal> shown after a status code means that the node is
+        not responding.
+       </para>
+       <para>
+        Thus, when a node is marked as <literal>down*</literal>, this means that
+        the node is not reachable due to network issues, or its
+        <literal>slurmd</literal> is not running.
+       </para>
+       <para>        
+        In the <literal>down</literal> state, the node is reachable, but the
+        node was rebooted unexpectedly, the hardware does not match the
+        description in <filename>slurm.conf</filename>, or a healthcheck was
        </para>
       </answer>
     </qandaentry>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -13,7 +13,7 @@
   <abstract>
    <para>
     <emphasis>Slurm</emphasis> is a workload manager for managing compute jobs
-    on high performance computing clusters. It can start multiple jobs on a
+    on high-performance computing clusters. It can start multiple jobs on a
     single node or a single job on multiple nodes. Additional components can be
     used for advanced scheduling and accounting.
    </para>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -1264,6 +1264,7 @@ SlurmdTimeout=3600</screen>
         In the <literal>down</literal> state, the node is reachable, but the
         node was rebooted unexpectedly, the hardware does not match the
         description in <filename>slurm.conf</filename>, or a healthcheck was
+        configured with the <literal>HealthCheckProgram</literal>.
        </para>
       </answer>
     </qandaentry>


### PR DESCRIPTION
This has been pending for months. I overlooked it and am catching up now I am working on the HPC docs.

Source: https://gitlab.nue.suse.com/documentation/release-notes-hpc ,
branch `sknorr-152-edit`, but you only need to check the commit diffs
for 2763abba, 3df437f8c5, c0f11d127, b57d6210.
(I.e. run `git show HASH`.)

Target: https://github.com/SUSE/doc-hpc , branch `master`.

Obviously I am now on `main` instead.

I have made all changes up until the section about Slurm and slurm-munge, where the relnotes and docs seem to go out of sync and a large amount of material is missing from then on. I will bring this across next.