### PR TITLE
Completion of overall copy-edit of new HPC Guide

### DIFF
--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -65,7 +65,7 @@
     Pick the appropriate file for your shell. Then add the following line into
     your shell's init file:
    </para>
-<screen>source /usr/share/lmod/lmod/init/&lt;INIT-FILE&gt;</screen>
+<screen>source /usr/share/lmod/lmod/init/<replaceable>INIT-FILE</replaceable></screen>
    <para>
     The init script adds the command <command>module</command>.
    </para>
@@ -759,12 +759,12 @@
    <title>memkind &mdash; heap manager for heterogeneous memory platforms and mixed memory policies</title>
    <para>
     The <emphasis>memkind</emphasis> library is a user-extensible heap manager
-    built on top of <literal>jemalloc</literal> which enables control of memory
-    characteristics and a partitioning of the heap between kinds of memory. The
-    kinds of memory are defined by operating system memory policies that have
-    been applied to virtual address ranges. Memory characteristics supported by
-    <literal>memkind</literal> without user extension include control of NUMA
-    and page size features.
+    built on top of <emphasis>jemalloc</emphasis> which enables control of
+    memory characteristics and a partitioning of the heap between kinds of
+    memory. The kinds of memory are defined by operating system memory policies
+    that have been applied to virtual address ranges. Memory characteristics
+    supported by <package>memkind</package> without user extension include
+    control of NUMA and page size features.
    </para>
    <para>
     For more information, see:
@@ -797,9 +797,9 @@
 <!-- href="https://fate.novell.com/324151" -->
    <title>MUMPS &mdash; MUltifrontal Massively Parallel sparse direct Solver</title>
    <para>
-    MUMPS (MUltifrontal Massively Parallel sparse direct Solver) solves a
-    sparse system of linear equations (<literal>A x = b</literal>) using
-    Gaussian elimination.
+    MUMPS (not to be confused with the database programming language with the
+    same acronym) solves a sparse system of linear equations
+    (<emphasis>A x = b</emphasis>) using Gaussian elimination.
    </para>
    <para>
     This library requires a compiler toolchain and an MPI flavor to be loaded

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -759,7 +759,7 @@
    <title>memkind &mdash; heap manager for heterogeneous memory platforms and mixed memory policies</title>
    <para>
     The <emphasis>memkind</emphasis> library is a user-extensible heap manager
-    built on top of <emphasis>jemalloc</emphasis> which enables control of
+    built on top of <emphasis>jemalloc</emphasis> which enables control over
     memory characteristics and a partitioning of the heap between kinds of
     memory. The kinds of memory are defined by operating system memory policies
     that have been applied to virtual address ranges. Memory characteristics

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -168,13 +168,13 @@
    <para>
     To install <package>gnu-compilers-hpc</package>, run:
    </para>
-<screen>zypper in gnu-compilers-hpc</screen>
+<screen>&prompt;zypper in gnu-compilers-hpc</screen>
    <para>
     To make libraries built with the base compilers available, you need to set
     up the environment appropriately and select the GNU toolchain. To do so,
     run:
    </para>
-<screen>module load gnu</screen>
+<screen>&prompt;module load gnu</screen>
   </sect2>
 
   <sect2>
@@ -199,14 +199,14 @@
     The Development Tools Module may provide later versions of the GNU compiler
     suite. To determine the available compiler suites, run:
    </para>
-<screen>zypper search '*-compilers-hpc'</screen>
+<screen>&prompt;zypper search '*-compilers-hpc'</screen>
    <para>
     If you have more than one version of the compiler suite installed,
     <emphasis>Lmod</emphasis> will pick the latest one by default. If you
     require an older version&mdash;or the base version&mdash;append the version
     number:
    </para>
-<screen>module load gnu/7</screen>
+<screen>&prompt;module load gnu/7</screen>
    <para>
     For more information, see: <xref linkend="sec-compute-lmod"/>.
    </para>
@@ -294,7 +294,7 @@
    suite. To view available compilers, run:
   </para>
 
-<screen>zypper search '*-compilers-hpc'</screen>
+<screen>&prompt;zypper search '*-compilers-hpc'</screen>
 
   <sect2 xml:id="sec2-lib-boost">
    <title><literal>boost</literal> &mdash; Boost C++ Libraries</title>
@@ -308,19 +308,18 @@
    <para>
     To load the highest available serial version of this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> boost</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> boost</screen>
    <para>
     or
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> boost</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> boost</screen>
    <para>
     if MPI specific boost libraries are to be used.
    </para>
    <para>
-    For information on the toolchain to load, check:
-    <xref
-     linkend="sec-compiler"/>, information on available MPI flavors
-    can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information about the toolchain to load, see: <xref
+    linkend="sec-compiler"/>. For information about available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -382,16 +381,15 @@
     variant, the respective MPI module needs to be loaded beforehand. To load
     this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> fftw3</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> fftw3</screen>
    <para>
     or
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> fftw3</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> fftw3</screen>
    <para>
-    For information on the toolchain to load, check:
-    <xref
-     linkend="sec-compiler"/>, information on available MPI flavors
-    can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information about the toolchain to load, see: <xref
+    linkend="sec-compiler"/>. For information about available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -434,9 +432,9 @@
    </para>
    <para>
     NumPy is built on the Numeric code base and adds features introduced by
-    numarray as well as an extended C API and the ability to create arrays of
-    arbitrary type which also makes NumPy suitable for interfacing with
-    general-purpose data-base applications.
+    <emphasis>numarray</emphasis>, as well as an extended C API, and the ability
+    to create arrays of arbitrary type, which also makes NumPy suitable for
+    interfacing with general-purpose database applications.
    </para>
    <para>
     There are also basic facilities for discrete Fourier transform, basic
@@ -448,10 +446,9 @@
     module for the Python version used needs to be specified when loading this
     module. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-numpy</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-numpy</screen>
    <para>
-    For information on the toolchain to load, check:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>.
    </para>
    <para>
@@ -498,10 +495,9 @@
     The correct library module for the Python version used needs to be
     specified when loading this module. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-scipy</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-scipy</screen>
    <para>
-    For information on the toolchain to load, check:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>.
    </para>
    <para>
@@ -539,10 +535,9 @@
     For this library, a compiler toolchain and an MPI flavor needs to be loaded
     beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> hypre</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> hypre</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>. For information on available MPI
     flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
@@ -594,10 +589,9 @@
     For this library a compiler toolchain needs to be loaded beforehand. To
     load metis, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> metis</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> metis</screen>
    <para>
-    For information on the toolchain to load, check:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>.
    </para>
    <para>
@@ -650,10 +644,9 @@
     For this library a compiler toolchain needs to be loaded beforehand. To
     load gsl, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> gsl</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> gsl</screen>
    <para>
-    For information on the toolchain to load, check:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>.
    </para>
    <para>
@@ -689,32 +682,31 @@
   </sect2>
 
   <sect2 xml:id="sec-lib-ocr">
-   <title>ocr &mdash; Open Community Runtime (OCR) for Shared Memory</title>
+   <title>OCR &mdash; Open Community Runtime (OCR) for Shared Memory</title>
    <para>
     The Open Community Runtime project is an application building framework
     that explores methods for high-core-count programming with focus on HPC
     applications.
    </para>
    <para>
-    This first reference implementation is functionally complete to the OCR
-    1.0.0 specification, with extensive tools and demonstration examples,
-    running on both single-node and clusters.
+    This first reference implementation is a functionally-complete
+    implementation of the OCR 1.0.0 specification, with extensive tools and
+    demonstration examples, running on both single nodes and clusters.
    </para>
    <para>
     This library is available both without and with MPI support. For this
-    library a compiler toolchain and if applicable, an MPI flavor needs to be
-    loaded beforehand. To load ocr, run:
+    library, a compiler toolchain, and if applicable an MPI flavor, need to be
+    loaded beforehand. To load <package>ocr</package>, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> ocr</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> ocr</screen>
    <para>
     or
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> ocr</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> ocr</screen>
    <para>
-    For information on the toolchain to load, check:
-    <xref
-     linkend="sec-compiler"/>, information on available MPI flavors
-    can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information about the toolchain to load, see: <xref
+    linkend="sec-compiler"/>. For information on available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -806,16 +798,16 @@
    <title>MUMPS &mdash; MUltifrontal Massively Parallel sparse direct Solver</title>
    <para>
     MUMPS (MUltifrontal Massively Parallel sparse direct Solver) solves a
-    sparse system of linear equations A x = b using Gaussian elimination.
+    sparse system of linear equations (<literal>A x = b</literal>) using
+    Gaussian elimination.
    </para>
    <para>
     This library requires a compiler toolchain and an MPI flavor to be loaded
     beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> mumps</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> mumps</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>. For information on available MPI
     flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
@@ -864,9 +856,9 @@
    <para>
     OpenBLAS is an optimized BLAS (Basic Linear Algebra Subprograms) library
     based on GotoBLAS2 1.3, BSD version. It provides the BLAS API. It is
-    shipped as a package enabled for environment modules and thus requires
+    shipped as a package enabled for environment modules, and thus requires
     using Lmod to select a version. There are two variants of this library, an
-    OpenMP-enabled variant and a pthreads variant.
+    OpenMP-enabled variant and a <literal>pthreads</literal> variant.
    </para>
    <bridgehead renderas="sect5">OpenMP-Enabled Variant</bridgehead>
    <para>
@@ -917,18 +909,17 @@
      <para>
       standard version:
      </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> openblas</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> openblas</screen>
     </listitem>
     <listitem>
      <para>
       OpenMP/pthreads version:
      </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> openblas-pthreads</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> openblas-pthreads</screen>
     </listitem>
    </itemizedlist>
    <para>
-    For information on the toolchain to load, check:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>.
    </para>
    <para>
@@ -970,12 +961,11 @@
     This module requires loading a compiler toolchain as well as an MPI library
     flavor beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> petsc</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> petsc</screen>
    <para>
-    For information on the toolchain to load, check:
-    <xref
-     linkend="sec-compiler"/>, information on available MPI flavors
-    can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information about the toolchain to load, see: <xref
+    linkend="sec-compiler"/>. For information about available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1010,12 +1000,11 @@
     This library requires loading both a compiler toolchain and an MPI library
     flavor beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> scalapack</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> scalapack</screen>
    <para>
-    For information on the toolchain to load, check:
-    <xref
-     linkend="sec-compiler"/>, information on available MPI flavors
-    can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information about the toolchain to load, see: <xref
+    linkend="sec-compiler"/>. For information about available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1056,12 +1045,11 @@
     For this library a compiler toolchain and an MPI flavor needs to be loaded
     beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> scotch</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> scotch</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
-     linkend="sec-compiler"/>. For information on available MPI
-    flavors, see: <xref linkend="sec1-MPI-libs"/>.
+    For information about the toolchain to load, see: <xref
+    linkend="sec-compiler"/>. For information about available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1089,7 +1077,7 @@
 <!-- href="https://fate.novell.com/324150" -->
    <title>SuperLU &mdash; supernodal LU decomposition of sparse matrices</title>
    <para>
-    SuperLU is a general purpose library for the direct solution of large,
+    SuperLU is a general-purpose library for the direct solution of large,
     sparse, nonsymmetric systems of linear equations. The library is written in
     C and can be called from C and Fortran programs.
    </para>
@@ -1107,7 +1095,7 @@
     substitution. The LU factorization routines can handle non-square matrices,
     but the triangular solves are performed only for square matrices. The
     matrix columns can be preordered (before factorization) either through
-    library or user supplied routines. This preordering for sparsity is
+    library or user-supplied routines. This preordering for sparsity is
     completely separate from the factorization. Working precision iterative
     refinement subroutines are provided for improved backward stability.
     Routines are also provided to equilibrate the system, estimate the
@@ -1118,10 +1106,9 @@
     This library requires a compiler toolchain and an MPI flavor to be loaded
     beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> superlu</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> superlu</screen>
    <para>
-    For information on the toolchain to load, check:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>.
    </para>
    <para>
@@ -1164,10 +1151,9 @@
     This library needs a compiler toolchain and and MPI flavor to be loaded
     beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> trilinos</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> trilinos</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>. For information on available MPI
     flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
@@ -1199,12 +1185,11 @@
     read, or processed outside of the running simulation. For more information,
     see <link xlink:href="https://www.olcf.ornl.gov/center-projects/adios/"/>.
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> adios</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> adios</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
-     linkend="sec-compiler"/>. For information on available MPI
-    flavors, see: <xref linkend="sec1-MPI-libs"/>.
+    For information about the toolchain to load, see: <xref
+    linkend="sec-compiler"/>. For information about available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1229,11 +1214,11 @@
 
   <sect2 xml:id="sec2-lib-hdf5">
 <!-- href="https://fate.novell.com/321710" -->
-   <title>HDF5 HPC library &mdash; model, library, file format for storing and managing data</title>
+   <title>HDF5 HPC library &mdash; model, library, and file format for storing and managing data</title>
    <para>
     HDF5 is a data model, library, and file format for storing and managing
     data. It supports an unlimited variety of data types, and is designed for
-    flexible and efficient I/O and for high volume and complex data. HDF5 is
+    flexible and efficient I/O and for high-volume and complex data. HDF5 is
     portable and extensible, allowing applications to evolve in their use of
     HDF5.
    </para>
@@ -1245,17 +1230,16 @@
    <para>
     To load the highest available serial version of this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> hdf5</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> hdf5</screen>
    <para>
     When an MPI flavor is loaded, the MPI version of this module can be loaded
     by:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> phpdf5</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> phpdf5</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
-     linkend="sec-compiler"/>. For information on available MPI
-    flavors, see: <xref linkend="sec1-MPI-libs"/>.
+    For information about the toolchain to load, see: <xref
+    linkend="sec-compiler"/>. For information about available MPI flavors, see:
+    <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1353,11 +1337,10 @@
     variants require loading a compiler toolchain module beforehand. To load
     the highest version of the non-MPI <literal>netcdf</literal> module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> netcdf</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> netcdf</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
-     linkend="sec-compiler"/>, For information on available MPI
+    For information about the toolchain to load, see: <xref
+     linkend="sec-compiler"/>. For information on available MPI
     flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
@@ -1413,10 +1396,9 @@
     This module requires loading a compiler toolchain module beforehand. To
     load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> netcdf-cxx4</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> netcdf-cxx4</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>.
    </para>
    <para>
@@ -1456,14 +1438,13 @@
     the highest version of the non-MPI <literal>netcdf-fortran</literal>
     module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> netcdf-fortran</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> netcdf-fortran</screen>
    <para>
     or
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> netcdf-fortran</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> netcdf-fortran</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>, For information on available MPI
     flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
@@ -1505,7 +1486,7 @@
   </sect2>
 
   <sect2 xml:id="sec2-lib-pnetcdf">
-   <title>HPC flavor of <literal>pnetcdf</literal> has been added</title>
+   <title>HPC flavor of <literal>pnetcdf</literal></title>
    <para>
     NetCDF is a set of software libraries and self-describing,
     machine-independent data formats that support the creation, access, and
@@ -1517,16 +1498,16 @@
     NetCDF by Unidata.
    </para>
    <para>
-    The package is available for the MPI Flavors: Open MPI 2 and 3, MVAPICH2
+    The package is available for the MPI Flavors Open MPI 2 and 3, MVAPICH2,
     and MPICH.
    </para>
    <para>
     To load the highest available serial version of this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> pnetcdf</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable>
+ <replaceable>MPI_FLAVOR</replaceable> pnetcdf</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>. For information on available MPI
     flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
@@ -1678,31 +1659,30 @@
     <para>
      For Open MPI v.3:
     </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> openmpi/3</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> openmpi/3</screen>
    </listitem>
    <listitem>
     <para>
      For Open MPI v.4:
     </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> openmpi/4</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> openmpi/4</screen>
    </listitem>
    <listitem>
     <para>
      For MVAPICH2:
     </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> mvapich2</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> mvapich2</screen>
    </listitem>
    <listitem>
     <para>
      For MPICH:
     </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> mpich</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> mpich</screen>
    </listitem>
   </itemizedlist>
 
   <para>
-   For information on the toolchain to load, check:
-   <xref
+   For information about the toolchain to load, check: <xref
     linkend="sec-compiler"/>.
   </para>
  </sect1>
@@ -1734,10 +1714,9 @@
     For the IMB binaries to be found, a compiler toolchain and an MPI flavor
     need to be loaded beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> imb</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> imb</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>. For information on available MPI
     flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
@@ -1763,10 +1742,9 @@
     compiler toolchain to be selected. The latest version provided can be
     loaded by running:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> papi</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> papi</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>.
    </para>
    <para>
@@ -1785,8 +1763,7 @@
     </listitem>
    </itemizedlist>
    <para>
-    For general information about Lmod and modules, see
-    <xref
+    For general information about Lmod and modules, see: <xref
      linkend="sec-compute-lmod"/>.
    </para>
   </sect2>
@@ -1806,10 +1783,9 @@
     For this library a compiler toolchain and and MPI flavor needs to be loaded
     beforehand. To load this module, run:
    </para>
-<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> mpip</screen>
+<screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> mpip</screen>
    <para>
-    For information on the toolchain to load, see:
-    <xref
+    For information about the toolchain to load, see: <xref
      linkend="sec-compiler"/>. For information on available MPI
     flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -431,10 +431,10 @@
     sacrificing too much speed for small multi-dimensional arrays.
    </para>
    <para>
-    NumPy is built on the Numeric code base and adds features introduced by
-    <emphasis>numarray</emphasis>, as well as an extended C API, and the ability
-    to create arrays of arbitrary type, which also makes NumPy suitable for
-    interfacing with general-purpose database applications.
+    NumPy is built on the Numeric code base and adds features introduced by the
+    discontinued <emphasis>NumArray</emphasis> project, as well as an extended
+    C API, and the ability to create arrays of arbitrary type, which also makes
+    NumPy suitable for interfacing with general-purpose database applications.
    </para>
    <para>
     There are also basic facilities for discrete Fourier transform, basic
@@ -839,11 +839,11 @@
   </sect2>
 
   <sect2 xml:id="sec2-lib-pmix">
-   <title>Support for PMIx in Slurm and MPI libraries</title>
+   <title>Support for PMIx in &slurm; and MPI libraries</title>
    <para>
     PMIx abstracts the internals of MPI implementations for workload managers
     and unifies the way MPI jobs are started by the workload manager: With
-    PMIx, there is no need to utilize the individual MPI launchers on Slurm
+    PMIx, there is no need to utilize the individual MPI launchers on &slurm;
     anymore, <command>srun</command> will take care of this. In addition, the
     workload manager can determine the topology of the cluster. This removes
     the need for users to specify topologies manually.

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -7,11 +7,10 @@
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
-
 <chapter xml:id="cha-compute" xml:lang="en"
-         xmlns="http://docbook.org/ns/docbook" version="5.1"
-         xmlns:xi="http://www.w3.org/2001/XInclude"
-         xmlns:xlink="http://www.w3.org/1999/xlink">
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>HPC user libraries</title>
  <info>
   <abstract>
@@ -20,93 +19,92 @@
     each of which has its own very specific library dependencies. Multiple
     instances of the same libraries may exist - differing in version, build
     configuration, compiler and MPI implementation used. To manage these
-    dependencies, an Environment Module system is often used.
-    Most HPC libraries provided with &shpca; are built with support for
-    environment modules.
-    This chapter describes the Environment Module system
-    <emphasis>Lmod</emphasis>, its setup and use as well as a set of
-    HPC compute libraries shipped with &shpca;.
+    dependencies, an Environment Module system is often used. Most HPC
+    libraries provided with &shpca; are built with support for environment
+    modules. This chapter describes the Environment Module system
+    <emphasis>Lmod</emphasis>, its setup and use as well as a set of HPC
+    compute libraries shipped with &shpca;.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:bugtracker></dm:bugtracker>
+   <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
  <sect1 xml:id="sec-compute-lmod">
   <title>Lmod &mdash; Lua-based environment modules</title>
+
   <para>
-   Lmod is an advanced environment module system which allows the
-   installation of multiple versions of a program or shared library, and
-   helps configure the system environment for the use of a specific
-   version. It
-   supports hierarchical library dependencies and makes sure that the
-   correct version of dependent libraries are selected. Environment
-   Modules-enabled library packages supplied with the HPC module support
-   parallel installation of different versions and flavors of the same
-   library or binary and are supplied with appropriate
-   <literal>lmod</literal> module files.
+   Lmod is an advanced environment module system which allows the installation
+   of multiple versions of a program or shared library, and helps configure the
+   system environment for the use of a specific version. It supports
+   hierarchical library dependencies and makes sure that the correct version of
+   dependent libraries are selected. Environment Modules-enabled library
+   packages supplied with the HPC module support parallel installation of
+   different versions and flavors of the same library or binary and are
+   supplied with appropriate <literal>lmod</literal> module files.
   </para>
+
   <sect2 xml:id="sec2-compute-lmod-basic">
    <title>Installation and basic usage</title>
    <para>
     To install Lmod, run: <command>zypper in lua-lmod</command>.
    </para>
    <para>
-    Before Lmod can be used, an init file needs to be sourced from the
-    initialization file of your interactive shell. The following init files
-    are available:
+    Before Lmod can be used, you must <command>source</command> an
+    <filename>init</filename> file into the initialization file of your
+    interactive shell. The following init files are available for various
+    common shells:
    </para>
-   <screen>/usr/share/lmod/lmod/init/bash
- /usr/share/lmod/lmod/init/ksh
- /usr/share/lmod/lmod/init/tcsh
- /usr/share/lmod/lmod/init/zsh
- /usr/share/lmod/lmod/init/sh</screen>
+<screen>/usr/share/lmod/lmod/init/bash
+/usr/share/lmod/lmod/init/ksh
+/usr/share/lmod/lmod/init/tcsh
+/usr/share/lmod/lmod/init/zsh
+/usr/share/lmod/lmod/init/sh</screen>
    <para>
-    Pick the appropriate file for your shell. Then add the following to the
-    init file of your shell:
+    Pick the appropriate file for your shell. Then add the following line into
+    your shell's init file:
    </para>
-   <screen>source /usr/share/lmod/lmod/init/&lt;INIT-FILE&gt;</screen>
+<screen>source /usr/share/lmod/lmod/init/&lt;INIT-FILE&gt;</screen>
    <para>
     The init script adds the command <command>module</command>.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-compute-lmod-lista">
    <title>Listing available modules</title>
    <para>
-    To list all the available modules, run:
-    <command>module spider</command>.
+    To list all the available modules, run: <command>module spider</command>.
     To show all modules which can be loaded with the currently loaded modules,
-    run: 
-    <command>module avail</command>.
-    A module name consists of a name and a version string, separated by a
-    <literal>/</literal> character. If more than one version is available
-    for a certain module name, the default version (marked by
-    <literal>*</literal>). If there is no default, the one with the highest
-    version number is loaded. To reference a specific module version, you can
-    use the full string
+    run: <command>module avail</command>. A module name consists of a name and
+    a version string, separated by a <literal>/</literal> character. If more
+    than one version is available for a certain module name, the default
+    version (marked by <literal>*</literal>). If there is no default, the one
+    with the highest version number is loaded. To reference a specific module
+    version, you can use the full string
     <literal><replaceable>NAME</replaceable>/<replaceable>VERSION</replaceable></literal>.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-compute-lmod-listl">
    <title>Listing loaded modules</title>
    <para>
-    <command>module list</command> shows all currently loaded modules. Refer
-    to <command>module help</command> for some short help on the module command,
+    <command>module list</command> shows all currently loaded modules. Refer to
+    <command>module help</command> for some short help on the module command,
     and <command>module help <replaceable>MODULE-NAME</replaceable></command>
-    for help on the particular module.
-    The <command>module</command> command is only available when you log in
-    after installing <literal>lua-lmod</literal>.
+    for help on the particular module. The <command>module</command> command is
+    only available when you log in after installing
+    <literal>lua-lmod</literal>.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-compute-lmod-info">
    <title>Gathering information about a module</title>
    <para>
-    To get information about a particular module, run:
-    <command>module whatis <replaceable>MODULE-NAME</replaceable></command>.
-    To load a module, run:
-    <command>module load <replaceable>MODULE-NAME</replaceable></command>.
-    This will ensure that your environment is modified (that is, the
+    To get information about a particular module, run: <command>module whatis
+    <replaceable>MODULE-NAME</replaceable></command>. To load a module, run:
+    <command>module load <replaceable>MODULE-NAME</replaceable></command>. This
+    will ensure that your environment is modified (that is, the
     <literal>PATH</literal> and <literal>LD_LIBRARY_PATH</literal> and other
     environment variables are prepended), such that binaries and libraries
     provided by the respective modules are found. To run a program compiled
@@ -114,16 +112,17 @@
     commands must be issued beforehand.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-compute-lmod-load">
    <title>Loading modules</title>
    <para>
     The <command>module load <replaceable>MODULE</replaceable></command>
-    command needs to be
-    run in the shell from which the module is to be used. Some modules
-    require a compiler toolchain or MPI flavor module to be loaded before
-    they are available for loading.
+    command needs to be run in the shell from which the module is to be used.
+    Some modules require a compiler toolchain or MPI flavor module to be loaded
+    before they are available for loading.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-compute-lmod-env">
    <title>Environment variables</title>
    <para>
@@ -131,34 +130,37 @@
     environment variables like <literal>LIBRARY_PATH</literal>,
     <literal>CPATH</literal>, <literal>C_INCLUDE_PATH</literal> and
     <literal>CPLUS_INCLUDE_PATH</literal> will be set up to include the
-    directories containing the appropriate header and library files.
-    However, some compiler and linker commands may not honor these. In this
-    case, use the appropriate options together with the environment
-    variables <literal>-I <replaceable>PACKAGE_NAME</replaceable>_INC</literal>
-    and <literal>-L <replaceable>PACKAGE_NAME</replaceable>_LIB</literal>
-    to add the include and library paths
-    to the command lines of the compiler and linker.
+    directories containing the appropriate header and library files. However,
+    some compiler and linker commands may not honor these. In this case, use
+    the appropriate options together with the environment variables <literal>-I
+    <replaceable>PACKAGE_NAME</replaceable>_INC</literal> and <literal>-L
+    <replaceable>PACKAGE_NAME</replaceable>_LIB</literal> to add the include
+    and library paths to the command lines of the compiler and linker.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-compute-lmod-moreinfo">
    <title>For more information</title>
    <para>
     For more information on Lmod, see
-    <link xlink:href="https://lmod.readthedocs.org"/>.
+    <link
+     xlink:href="https://lmod.readthedocs.org"/>.
    </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-compiler">
-     <title>GNU Compiler Toolchain Collection for HPC</title>
-   <para>
-    On &shpca; the GNU compiler collection version 7 is provided as base
-    compiler toolchain.
-    The <package>gnu-compilers-hpc</package> provides the environment module
-    for the base version of the GNU compiler suite. This package must be installed
-    when using any of the HPC libraries enabled for environment modules.
-   </para>
-   <sect2>
-    <title>Environment module</title>
+  <title>GNU Compiler Toolchain Collection for HPC</title>
+
+  <para>
+   On &shpca; the GNU compiler collection version 7 is provided as base
+   compiler toolchain. The <package>gnu-compilers-hpc</package> provides the
+   environment module for the base version of the GNU compiler suite. This
+   package must be installed when using any of the HPC libraries enabled for
+   environment modules.
+  </para>
+
+  <sect2>
+   <title>Environment module</title>
    <para>
     This package requires <package>lua-lmod</package> to supply environment
     module support.
@@ -169,75 +171,79 @@
 <screen>zypper in gnu-compilers-hpc</screen>
    <para>
     To make libraries built with the base compilers available, you need to set
-    up the environment appropriately and select the GNU toolchain.
-    To do so, run:
+    up the environment appropriately and select the GNU toolchain. To do so,
+    run:
    </para>
 <screen>module load gnu</screen>
-   </sect2>
-   <sect2>
-    <title>Building HPC software with GNU Compiler Suite</title>
-    <para>
-     To use the GNU compiler collection to build your own libraries and
-     applications, <package>gnu-compilers-hpc-devel</package> needs to be
-     installed. It makes sure all compiler components required for HPC (that is,
-     C, C++, and Fortran compilers) are installed.
-    </para>
-    <para>
-     The environment variables <literal>CC</literal>, <literal>CXX</literal>,
-     <literal>FC</literal> and <literal>F77</literal> will be set correctly
-     and the path will be adjusted so that the correct compiler version will
-     be found.
-    </para>
-   </sect2>
-   <sect2>
-    <title>Later versions</title>
-    <para>
-     The Development Tools Module may provide later versions of the GNU
-     compiler suite. To determine the available compiler suites, run:
-    </para>
+  </sect2>
+
+  <sect2>
+   <title>Building HPC software with GNU Compiler Suite</title>
+   <para>
+    To use the GNU compiler collection to build your own libraries and
+    applications, <package>gnu-compilers-hpc-devel</package> needs to be
+    installed. It makes sure all compiler components required for HPC (that is,
+    C, C++, and Fortran compilers) are installed.
+   </para>
+   <para>
+    The environment variables <literal>CC</literal>, <literal>CXX</literal>,
+    <literal>FC</literal> and <literal>F77</literal> will be set correctly and
+    the path will be adjusted so that the correct compiler version will be
+    found.
+   </para>
+  </sect2>
+
+  <sect2>
+   <title>Later versions</title>
+   <para>
+    The Development Tools Module may provide later versions of the GNU compiler
+    suite. To determine the available compiler suites, run:
+   </para>
 <screen>zypper search '*-compilers-hpc'</screen>
-    <para>
-     If you have more than one version of the compiler suite installed,
-     <emphasis>Lmod</emphasis> will pick the latest one by default. If you
-     require an older version&mdash;or the base version&mdash;append the version
-     number:
-    </para>
+   <para>
+    If you have more than one version of the compiler suite installed,
+    <emphasis>Lmod</emphasis> will pick the latest one by default. If you
+    require an older version&mdash;or the base version&mdash;append the version
+    number:
+   </para>
 <screen>module load gnu/7</screen>
-    <para>
-     For more information, see: <xref linkend="sec-compute-lmod"/>.
-    </para>
-   </sect2>
+   <para>
+    For more information, see: <xref linkend="sec-compute-lmod"/>.
+   </para>
+  </sect2>
  </sect1>
  <sect1 xml:id="sec-compute-lib">
   <title>HPC libraries</title>
+
   <para>
    Library packages which support environment modules follow a distinctive
-   naming scheme: All packages have the compiler suite and, if built with
-   MPI support, the MPI flavor included in their name:
+   naming scheme: All packages have the compiler suite and, if built with MPI
+   support, the MPI flavor included in their name:
    <literal>*-[<replaceable>MPI_FLAVOR</replaceable>-]<replaceable>COMPILER</replaceable>-hpc*</literal>.
    To facilitate the parallel installation of multiple versions of a library,
-   the package name contains the version number (with dots
-   <literal>.</literal> replaced by underscores <literal>_</literal>). To
-   simplify the installation of a library, <literal>master-</literal> packages
-   are supplied which will ensure that the latest version of a package is
-   installed. When these master packages are updated, the latest version of the
-   respective packages will be installed, while leaving previous versions
-   installed. Library packages are split between runtime and compile-time
-   packages. The compile-time packages typically supply <literal>include</literal>
-   files and <literal>.so</literal> files for shared libraries. Compile-time
-   package names end with <literal>-devel</literal>. For some libraries,
-   static (<literal>.a</literal>) libraries are supplied as well. Package names
-   for these end with <literal>-devel-static</literal>.
+   the package name contains the version number (with dots <literal>.</literal>
+   replaced by underscores <literal>_</literal>). To simplify the installation
+   of a library, <literal>master-</literal> packages are supplied which will
+   ensure that the latest version of a package is installed. When these master
+   packages are updated, the latest version of the respective packages will be
+   installed, while leaving previous versions installed. Library packages are
+   split between runtime and compile-time packages. The compile-time packages
+   typically supply <literal>include</literal> files and <literal>.so</literal>
+   files for shared libraries. Compile-time package names end with
+   <literal>-devel</literal>. For some libraries, static
+   (<literal>.a</literal>) libraries are supplied as well. Package names for
+   these end with <literal>-devel-static</literal>.
   </para>
+
   <para>
    As an example, package names of the ScaLAPACK library version 2.0.2 built
    with GCC for Open MPI v2:
   </para>
+
   <itemizedlist>
    <listitem>
     <para>
-     library package:
-     <package>libscalapack2_2_1_0-gnu-openmpi2-hpc</package>
+     library package: <package>libscalapack2_2_1_0-gnu-openmpi2-hpc</package>
     </para>
    </listitem>
    <listitem>
@@ -264,48 +270,57 @@
     </para>
    </listitem>
   </itemizedlist>
+
   <para>
    The digit <literal>2</literal> appended to the library name denotes the
    <literal>.so</literal> version of the library.
   </para>
+
   <para>
-   To install a library package, run:
-   <command>zypper in <replaceable>LIBRARY-MASTER-PACKAGE</replaceable></command>.
-   To install a development file, run
-   <command>zypper in <replaceable>LIBRARY-DEVEL-MASTER-PACKAGE</replaceable></command>.
+   To install a library package, run: <command>zypper in
+   <replaceable>LIBRARY-MASTER-PACKAGE</replaceable></command>. To install a
+   development file, run <command>zypper in
+   <replaceable>LIBRARY-DEVEL-MASTER-PACKAGE</replaceable></command>.
   </para>
+
   <para>
    Presently, the GNU compiler collection version 7 as provided with &shpca;
    and the MPI flavors Open MPI v.3 and v.4 as well as MPICH and MVAPICH2 are
    supported.
   </para>
+
   <para>
-   The Development Tools Module may provide later versions of the GNU
-   compiler suite. To view available compilers, run:
+   The Development Tools Module may provide later versions of the GNU compiler
+   suite. To view available compilers, run:
   </para>
+
 <screen>zypper search '*-compilers-hpc'</screen>
+
   <sect2 xml:id="sec2-lib-boost">
    <title><literal>boost</literal> &mdash; Boost C++ Libraries</title>
    <para>
     <literal>Boost</literal> is a set of portable C++ libraries which provide a
-    reference implementation of "existing practices".
-    See the full release notes for Boost 1.71 at
-    <link xlink:href="https://www.boost.org/users/history/version_1_71_0.html"/>.
+    reference implementation of "existing practices". See the full release
+    notes for Boost 1.71 at
+    <link
+     xlink:href="https://www.boost.org/users/history/version_1_71_0.html"/>.
    </para>
    <para>
     To load the highest available serial version of this module, run:
    </para>
-   <screen>module load <replaceable>TOOLCHAIN</replaceable> boost</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> boost</screen>
    <para>
-     or
+    or
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> boost</screen>
    <para>
     if MPI specific boost libraries are to be used.
    </para>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>, information on available MPI flavors
+    can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -323,31 +338,38 @@
     </listitem>
    </itemizedlist>
    <para>
-    Most Boost libraries do not depend on MPI flavors. However Boost
-    contains a set of libraries to abstract interaction with MPI. These
-    libraries depend on the MPI flavor used.
+    Most Boost libraries do not depend on MPI flavors. However Boost contains a
+    set of libraries to abstract interaction with MPI. These libraries depend
+    on the MPI flavor used.
    </para>
    <para>
     List of master packages:
    </para>
    <itemizedlist>
-    <listitem><para>
+    <listitem>
+     <para>
       <package>boost-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
-     </para></listitem>
-    <listitem><para>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       <package>boost-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</package>
-     </para></listitem>
-    <listitem><para>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       <package>boost-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-python3</package>
-     </para></listitem>
+     </para>
+    </listitem>
    </itemizedlist>
    <para>
-    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
-    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported MPI
+    flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-lib-fftw">
-   <!-- href="https://fate.novell.com/321716" -->
+<!-- href="https://fate.novell.com/321716" -->
    <title>FFTW HPC library &mdash; discrete Fourier transforms</title>
    <para>
     <literal>FFTW</literal> is a C subroutine library for computing the
@@ -355,19 +377,21 @@
     and complex data, and of arbitrary input size.
    </para>
    <para>
-    This library is available as both a serial and an MPI-enabled variant.
-    This module requires a compiler toolchain module loaded. To select an
-    MPI variant, the respective MPI module needs to be loaded beforehand. To
-    load this module, run:
+    This library is available as both a serial and an MPI-enabled variant. This
+    module requires a compiler toolchain module loaded. To select an MPI
+    variant, the respective MPI module needs to be loaded beforehand. To load
+    this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> fftw3</screen>
    <para>
-     or
+    or
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> fftw3</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>, information on available MPI flavors
+    can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -395,24 +419,23 @@
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
-    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported MPI
+    flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
 
   <sect2 xml:id="sec2-lib-numpy">
-   <!-- href="https://fate.novell.com/321709" -->
+<!-- href="https://fate.novell.com/321709" -->
    <title>NumPy Python library</title>
    <para>
-    NumPy is a general-purpose array-processing package designed to
-    efficiently manipulate large multi-dimensional arrays of arbitrary
-    records without sacrificing too much speed for small multi-dimensional
-    arrays.
+    NumPy is a general-purpose array-processing package designed to efficiently
+    manipulate large multi-dimensional arrays of arbitrary records without
+    sacrificing too much speed for small multi-dimensional arrays.
    </para>
    <para>
     NumPy is built on the Numeric code base and adds features introduced by
-    numarray as well as an extended C API and the ability to create arrays
-    of arbitrary type which also makes NumPy suitable for interfacing with
+    numarray as well as an extended C API and the ability to create arrays of
+    arbitrary type which also makes NumPy suitable for interfacing with
     general-purpose data-base applications.
    </para>
    <para>
@@ -420,15 +443,16 @@
     linear algebra, and random number generation.
    </para>
    <para>
-    This package is available both for Python 2 and 3. The specific
-    compiler toolchain module must be loaded for this library.
-    The correct library module for the Python version used needs
-    to be specified when loading this module. To load this module,
-    run:
+    This package is available both for Python 2 and 3. The specific compiler
+    toolchain module must be loaded for this library. The correct library
+    module for the Python version used needs to be specified when loading this
+    module. To load this module, run:
    </para>
-    <screen>module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-numpy</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-numpy</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -446,15 +470,17 @@
     </listitem>
    </itemizedlist>
   </sect2>
+
   <sect2 xml:id="sec2-lib-scipy">
-   <!-- href="https://fate.novell.com/321709" -->
+<!-- href="https://fate.novell.com/321709" -->
    <title>SciPy Python Library</title>
    <para>
     SciPy is a collection of mathematical algorithms and convenience functions
     built on the NumPy extension of Python. It adds significant power to the
-    interactive Python session by providing the user with high-level commands and
-    classes for manipulating and visualizing data. With SciPy, an interactive
-    Python session becomes a data-processing and system-prototyping environment.
+    interactive Python session by providing the user with high-level commands
+    and classes for manipulating and visualizing data. With SciPy, an
+    interactive Python session becomes a data-processing and system-prototyping
+    environment.
    </para>
    <para>
     The additional benefit of basing SciPy on Python is that this also makes a
@@ -462,19 +488,21 @@
     programs and specialized applications. Scientific applications using SciPy
     benefit from the development of additional modules in numerous niches of
     the software landscape by developers across the world. Everything from
-    parallel programming to web and data-base subroutines and classes have
-    been made available to the Python programmer. All of this power is
-    available in addition to the mathematical libraries in SciPy.
+    parallel programming to web and data-base subroutines and classes have been
+    made available to the Python programmer. All of this power is available in
+    addition to the mathematical libraries in SciPy.
    </para>
    <para>
-    This package is available both for Python 2 (up to version 1.2.0 only)
-    and 3. The specific compiler toolchain modules must be loaded for this
-    library. The correct library module for the Python version used needs
-    to be specified when loading this module. To load this module, run:
+    This package is available both for Python 2 (up to version 1.2.0 only) and
+    3. The specific compiler toolchain modules must be loaded for this library.
+    The correct library module for the Python version used needs to be
+    specified when loading this module. To load this module, run:
    </para>
-    <screen>module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-scipy</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> python<replaceable>PYTHON_VERSION</replaceable>-scipy</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -494,29 +522,29 @@
   </sect2>
 
   <sect2 xml:id="sec2-lib-hypre">
-   <!-- href="https://fate.novell.com/324153" -->
+<!-- href="https://fate.novell.com/324153" -->
    <title>HYPRE &mdash; scalable linear solvers and multigrid methods</title>
    <para>
     HYPRE is a library of linear solvers which aim to solve large and detailed
     simulations faster than traditional methods at large scales.
    </para>
    <para>
-    The library offers a comprehensive suite of scalable solvers for large-scale
-    scientific simulation, featuring parallel multigrid methods for both
-    structured and unstructured grid problems. HYPRE is highly portable and
-    supports a number of languages. It is developed at Lawrence Livermore
+    The library offers a comprehensive suite of scalable solvers for
+    large-scale scientific simulation, featuring parallel multigrid methods for
+    both structured and unstructured grid problems. HYPRE is highly portable
+    and supports a number of languages. It is developed at Lawrence Livermore
     National Laboratory.
    </para>
    <para>
-    For this library, a compiler toolchain and an MPI flavor
-    needs to be loaded beforehand. To load this module, run:
+    For this library, a compiler toolchain and an MPI flavor needs to be loaded
+    beforehand. To load this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> hypre</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>. For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -536,43 +564,41 @@
   </sect2>
 
   <sect2 xml:id="sec-lib-metis">
-   <title>METIS &mdash; Serial Graph Partitioning and Fill-reducing Matrix
-   Ordering Library</title>
+   <title>METIS &mdash; Serial Graph Partitioning and Fill-reducing Matrix Ordering Library</title>
    <para>
-    METIS is a set of serial programs for partitioning graphs,
-    partitioning finite element meshes, and producing fill reducing
-    orderings for sparse matrices. The algorithms implemented in
-    METIS are based on the multilevel recursive-bisection,
-    multilevel k-way, and multi-constraint partitioning schemes.
+    METIS is a set of serial programs for partitioning graphs, partitioning
+    finite element meshes, and producing fill reducing orderings for sparse
+    matrices. The algorithms implemented in METIS are based on the multilevel
+    recursive-bisection, multilevel k-way, and multi-constraint partitioning
+    schemes.
    </para>
    <para>
-    Experiments on a wide range of graphs has shown that METIS
-    is one to two orders of magnitude faster than other widely
-    used partitioning algorithms. Graphs with several millions
-    of vertices can be partitioned in 256 parts in a few seconds
-    on current generation systems.
+    Experiments on a wide range of graphs has shown that METIS is one to two
+    orders of magnitude faster than other widely used partitioning algorithms.
+    Graphs with several millions of vertices can be partitioned in 256 parts in
+    a few seconds on current generation systems.
    </para>
    <para>
-    The fill-reducing orderings produced by METIS are significantly
-    better than those produced by other widely used algorithms
-    including multiple minimum degree. For many classes of problems
-    arising in scientific computations and linear programming,
-    METIS is able to reduce the storage and computational
-    requirements of sparse matrix factorization, by up to an
-    order of magnitude. Moreover, unlike multiple minimum
-    degree, the elimination trees produced by METIS are suitable
-    for parallel direct factorization. Furthermore, METIS is able
-    to compute these orderings very fast. Matrices with millions
-    of rows can be reordered in just a few seconds on current
+    The fill-reducing orderings produced by METIS are significantly better than
+    those produced by other widely used algorithms including multiple minimum
+    degree. For many classes of problems arising in scientific computations and
+    linear programming, METIS is able to reduce the storage and computational
+    requirements of sparse matrix factorization, by up to an order of
+    magnitude. Moreover, unlike multiple minimum degree, the elimination trees
+    produced by METIS are suitable for parallel direct factorization.
+    Furthermore, METIS is able to compute these orderings very fast. Matrices
+    with millions of rows can be reordered in just a few seconds on current
     generation workstations and PCs.
    </para>
    <para>
-    For this library a compiler toolchain needs to be loaded
-    beforehand. To load metis, run:
+    For this library a compiler toolchain needs to be loaded beforehand. To
+    load metis, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> metis</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -609,25 +635,26 @@
   <sect2 xml:id="sec-lib-gsl">
    <title>gsl &mdash; GNU Scientific Library</title>
    <para>
-    The GNU Scientific Library (GSL) is a numerical library for C and
-    C++ programmers.
+    The GNU Scientific Library (GSL) is a numerical library for C and C++
+    programmers.
    </para>
    <para>
-    The library provides a wide range of mathematical routines such
-    as random number generators, special functions and least-squares
-    fitting. There are over 1000 functions in total with an extensive
-    test suite.
+    The library provides a wide range of mathematical routines such as random
+    number generators, special functions and least-squares fitting. There are
+    over 1000 functions in total with an extensive test suite.
    </para>
    <para>
     It is free software under the GNU General Public License.
    </para>
    <para>
-    For this library a compiler toolchain needs to be loaded
-    beforehand. To load gsl, run:
+    For this library a compiler toolchain needs to be loaded beforehand. To
+    load gsl, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> gsl</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -661,32 +688,33 @@
    </itemizedlist>
   </sect2>
 
-    <sect2 xml:id="sec-lib-ocr">
+  <sect2 xml:id="sec-lib-ocr">
    <title>ocr &mdash; Open Community Runtime (OCR) for Shared Memory</title>
    <para>
-    The Open Community Runtime project is an application
-    building framework that explores methods for high-core-count
-    programming with focus on HPC applications.
+    The Open Community Runtime project is an application building framework
+    that explores methods for high-core-count programming with focus on HPC
+    applications.
    </para>
    <para>
-    This first reference implementation is functionally
-    complete to the OCR 1.0.0 specification, with extensive
-    tools and demonstration examples, running on both
-    single-node and clusters.
+    This first reference implementation is functionally complete to the OCR
+    1.0.0 specification, with extensive tools and demonstration examples,
+    running on both single-node and clusters.
    </para>
    <para>
-    This library is available both without and with MPI support.
-    For this library a compiler toolchain and if applicable, an MPI
-    flavor needs to be loaded beforehand. To load ocr, run:
+    This library is available both without and with MPI support. For this
+    library a compiler toolchain and if applicable, an MPI flavor needs to be
+    loaded beforehand. To load ocr, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> ocr</screen>
    <para>
-     or
+    or
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> ocr</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>, information on available MPI flavors
+    can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -739,12 +767,12 @@
    <title>memkind &mdash; heap manager for heterogeneous memory platforms and mixed memory policies</title>
    <para>
     The <emphasis>memkind</emphasis> library is a user-extensible heap manager
-    built on top of <literal>jemalloc</literal> which enables control of
-    memory characteristics and a partitioning of the heap between kinds of
-    memory. The kinds of memory are defined by operating system memory
-    policies that have been applied to virtual address ranges. Memory
-    characteristics supported by <literal>memkind</literal> without user
-    extension include control of NUMA and page size features.
+    built on top of <literal>jemalloc</literal> which enables control of memory
+    characteristics and a partitioning of the heap between kinds of memory. The
+    kinds of memory are defined by operating system memory policies that have
+    been applied to virtual address ranges. Memory characteristics supported by
+    <literal>memkind</literal> without user extension include control of NUMA
+    and page size features.
    </para>
    <para>
     For more information, see:
@@ -752,8 +780,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      the man pages <literal>memkind</literal> and
-      <literal>hbwallow</literal>
+      the man pages <literal>memkind</literal> and <literal>hbwallow</literal>
      </para>
     </listitem>
     <listitem>
@@ -773,24 +800,24 @@
     </para>
    </note>
   </sect2>
+
   <sect2 xml:id="sec2-lib-mumps">
-   <!-- href="https://fate.novell.com/324151" -->
+<!-- href="https://fate.novell.com/324151" -->
    <title>MUMPS &mdash; MUltifrontal Massively Parallel sparse direct Solver</title>
    <para>
-    MUMPS (MUltifrontal Massively Parallel sparse direct Solver)
-    solves a sparse system of linear equations A x = b using
-    Gaussian elimination.
+    MUMPS (MUltifrontal Massively Parallel sparse direct Solver) solves a
+    sparse system of linear equations A x = b using Gaussian elimination.
    </para>
    <para>
-    This library requires a compiler toolchain and an MPI flavor
-    to be loaded beforehand. To load this module, run:
+    This library requires a compiler toolchain and an MPI flavor to be loaded
+    beforehand. To load this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> mumps</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>. For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -818,27 +845,28 @@
     </listitem>
    </itemizedlist>
   </sect2>
+
   <sect2 xml:id="sec2-lib-pmix">
    <title>Support for PMIx in Slurm and MPI libraries</title>
    <para>
-    PMIx abstracts the internals of MPI implementations for workload
-    managers and unifies the way MPI jobs are started by the workload
-    manager: With PMIx, there is no need to utilize the individual MPI
-    launchers on Slurm anymore, <command>srun</command> will take care of
-    this. In addition, the workload manager can determine the topology of
-    the cluster. This removes the need for users to specify topologies
-    manually.
+    PMIx abstracts the internals of MPI implementations for workload managers
+    and unifies the way MPI jobs are started by the workload manager: With
+    PMIx, there is no need to utilize the individual MPI launchers on Slurm
+    anymore, <command>srun</command> will take care of this. In addition, the
+    workload manager can determine the topology of the cluster. This removes
+    the need for users to specify topologies manually.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-lib-blas">
-   <!-- href="https://fate.novell.com/321708" -->
+<!-- href="https://fate.novell.com/321708" -->
    <title>OpenBLAS library &mdash; optimized BLAS library</title>
    <para>
     OpenBLAS is an optimized BLAS (Basic Linear Algebra Subprograms) library
     based on GotoBLAS2 1.3, BSD version. It provides the BLAS API. It is
     shipped as a package enabled for environment modules and thus requires
-    using Lmod to select a version. There are two variants of this library,
-    an OpenMP-enabled variant and a pthreads variant.
+    using Lmod to select a version. There are two variants of this library, an
+    OpenMP-enabled variant and a pthreads variant.
    </para>
    <bridgehead renderas="sect5">OpenMP-Enabled Variant</bridgehead>
    <para>
@@ -847,25 +875,25 @@
    <itemizedlist>
     <listitem>
      <para>
-      <emphasis role="bold">Programs using OpenMP.</emphasis> This requires
-      the OpenMP-enabled library version to function correctly.
+      <emphasis role="bold">Programs using OpenMP.</emphasis> This requires the
+      OpenMP-enabled library version to function correctly.
      </para>
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Programs using pthreads.</emphasis> This
-      requires an OpenBLAS library without pthread support. This can be
-      achieved with the OpenMP-version. We recommend limiting the number of
-      threads that are used to 1 by setting the environment variable
+      <emphasis role="bold">Programs using pthreads.</emphasis> This requires
+      an OpenBLAS library without pthread support. This can be achieved with
+      the OpenMP-version. We recommend limiting the number of threads that are
+      used to 1 by setting the environment variable
       <literal>OMP_NUM_THREADS=1</literal>.
      </para>
     </listitem>
     <listitem>
      <para>
       <emphasis role="bold">Programs without pthreads and without
-      OpenMP.</emphasis> Such programs can still take advantage of the
-      OpenMP optimization in the library by linking against the OpenMP
-      variant of the library.
+      OpenMP.</emphasis> Such programs can still take advantage of the OpenMP
+      optimization in the library by linking against the OpenMP variant of the
+      library.
      </para>
     </listitem>
    </itemizedlist>
@@ -875,15 +903,14 @@
    </para>
    <bridgehead renderas="sect5">pthreads Variant</bridgehead>
    <para>
-    The pthreads variant of the OpenBLAS library can improve the performance
-    of single-threaded programs. The number of threads used can be
-    controlled with the environment variable
-    <literal>OPENBLAS_NUM_THREADS</literal>.
+    The pthreads variant of the OpenBLAS library can improve the performance of
+    single-threaded programs. The number of threads used can be controlled with
+    the environment variable <literal>OPENBLAS_NUM_THREADS</literal>.
    </para>
    <bridgehead renderas="sect5">Installation and Usage</bridgehead>
    <para>
-    This module requires loading a compiler toolchain beforehand. To select
-    the latest version of this module provided, run:
+    This module requires loading a compiler toolchain beforehand. To select the
+    latest version of this module provided, run:
    </para>
    <itemizedlist>
     <listitem>
@@ -900,7 +927,9 @@
     </listitem>
    </itemizedlist>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -928,8 +957,9 @@
     </listitem>
    </itemizedlist>
   </sect2>
+
   <sect2 xml:id="sec2-lib-petsc">
-   <!-- href="https://fate.novell.com/321718" -->
+<!-- href="https://fate.novell.com/321718" -->
    <title>PETSc HPC library &mdash; solver for partial differential equations</title>
    <para>
     PETSc is a suite of data structures and routines for the scalable
@@ -937,13 +967,15 @@
     differential equations.
    </para>
    <para>
-    This module requires loading a compiler toolchain as well as an MPI
-    library flavor beforehand. To load this module, run:
+    This module requires loading a compiler toolchain as well as an MPI library
+    flavor beforehand. To load this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> petsc</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>, information on available MPI flavors
+    can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -961,12 +993,13 @@
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
-    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported MPI
+    flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-lib-scal">
-   <!-- href="https://fate.novell.com/321715" -->
+<!-- href="https://fate.novell.com/321715" -->
    <title>ScaLAPACK HPC library &mdash; LAPACK routines</title>
    <para>
     The library ScaLAPACK (short for <emphasis>Scalable LAPACK</emphasis>)
@@ -974,13 +1007,15 @@
     MIMD-parallel computers.
    </para>
    <para>
-    This library requires loading both a compiler toolchain and an MPI
-    library flavor beforehand. To load this module, run:
+    This library requires loading both a compiler toolchain and an MPI library
+    flavor beforehand. To load this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> scalapack</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>,
-    information on available MPI flavors can be found here: <xref linkend="sec1-MPI-libs"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>, information on available MPI flavors
+    can be found here: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -998,35 +1033,35 @@
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
-    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported MPI
+    flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-lib-scotch">
-   <!-- href="https://fate.novell.com/327141" -->
+<!-- href="https://fate.novell.com/327141" -->
    <title>SCOTCH &mdash; static mapping and sparse matrix reordering algorithms</title>
    <para>
-    SCOTCH is a set of programs and libraries which implement
-    the static mapping and sparse matrix reordering algorithms
-    developed within the SCOTCH project.
+    SCOTCH is a set of programs and libraries which implement the static
+    mapping and sparse matrix reordering algorithms developed within the SCOTCH
+    project.
    </para>
    <para>
-    Its purpose is to apply graph theory, with a divide and
-    conquer approach, to scientific computing problems such as
-    graph and mesh partitioning, static mapping, and sparse
-    matrix ordering, in application domains ranging from
-    structural mechanics to operating systems or bio-chemistry.
+    Its purpose is to apply graph theory, with a divide and conquer approach,
+    to scientific computing problems such as graph and mesh partitioning,
+    static mapping, and sparse matrix ordering, in application domains ranging
+    from structural mechanics to operating systems or bio-chemistry.
    </para>
    <para>
-    For this library a compiler toolchain and an MPI flavor
-    needs to be loaded beforehand. To load this module, run:
+    For this library a compiler toolchain and an MPI flavor needs to be loaded
+    beforehand. To load this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> scotch</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>. For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1042,20 +1077,21 @@
       <literal>ptscotch-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</literal>
      </para>
     </listitem>
-        <listitem>
+    <listitem>
      <para>
       <literal>ptscotch-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</literal>
      </para>
     </listitem>
    </itemizedlist>
   </sect2>
+
   <sect2 xml:id="sec2-lib-superlu">
-   <!-- href="https://fate.novell.com/324150" -->
+<!-- href="https://fate.novell.com/324150" -->
    <title>SuperLU &mdash; supernodal LU decomposition of sparse matrices</title>
    <para>
     SuperLU is a general purpose library for the direct solution of large,
-    sparse, nonsymmetric systems of linear equations. The library is written
-    in C and can be called from C and Fortran programs.
+    sparse, nonsymmetric systems of linear equations. The library is written in
+    C and can be called from C and Fortran programs.
    </para>
 <!-- Possible fixmes in the following para:
     * 5-word compound noun: "Working precision iterative refinement subroutines"
@@ -1067,24 +1103,26 @@
     It uses MPI and OpenMP to support various forms of parallelism. It supports
     both real and complex data types, both single and double precision, and
     64-bit integer indexing. The library routines performs an LU decomposition
-    with partial pivoting and triangular system solves through forward and
-    back substitution. The LU factorization routines can handle non-square
-    matrices, but the triangular solves are performed only for square matrices.
-    The matrix columns can be preordered (before factorization) either through
+    with partial pivoting and triangular system solves through forward and back
+    substitution. The LU factorization routines can handle non-square matrices,
+    but the triangular solves are performed only for square matrices. The
+    matrix columns can be preordered (before factorization) either through
     library or user supplied routines. This preordering for sparsity is
     completely separate from the factorization. Working precision iterative
     refinement subroutines are provided for improved backward stability.
     Routines are also provided to equilibrate the system, estimate the
-    condition number, calculate the relative backward error, and estimate
-    error bounds for the refined solutions.
+    condition number, calculate the relative backward error, and estimate error
+    bounds for the refined solutions.
    </para>
    <para>
-    This library requires a compiler toolchain and an MPI flavor
-    to be loaded beforehand. To load this module, run:
+    This library requires a compiler toolchain and an MPI flavor to be loaded
+    beforehand. To load this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> superlu</screen>
    <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
+    For information on the toolchain to load, check:
+    <xref
+     linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -1112,26 +1150,26 @@
     </listitem>
    </itemizedlist>
   </sect2>
+
   <sect2 xml:id="sec2-lib-trilinos">
-   <!-- href="https://fate.novell.com/324185" -->
+<!-- href="https://fate.novell.com/324185" -->
    <title>Trilinos &mdash; object-oriented software framework</title>
    <para>
-    The Trilinos Project is an effort to develop algorithms and
-    enabling technologies within an object-oriented software
-    framework for the solution of large-scale, complex
-    multi-physics engineering and scientific problems. A unique
-    design feature of Trilinos is its focus on packages.
+    The Trilinos Project is an effort to develop algorithms and enabling
+    technologies within an object-oriented software framework for the solution
+    of large-scale, complex multi-physics engineering and scientific problems.
+    A unique design feature of Trilinos is its focus on packages.
    </para>
    <para>
-    This library needs a compiler toolchain and and MPI flavor
-    to be loaded beforehand. To load this module, run:
+    This library needs a compiler toolchain and and MPI flavor to be loaded
+    beforehand. To load this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> trilinos</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>. For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1152,21 +1190,21 @@
  </sect1>
  <sect1 xml:id="FileFormat">
   <title>File format libraries</title>
+
   <sect2 xml:id="sec2-lib-adios">
    <title>Adaptable IO System (ADIOS)</title>
    <para>
     The Adaptable IO System (ADIOS) provides a simple, flexible way for
-    scientists to describe the data in their code that may need to be
-    written, read, or processed outside of the running simulation. For more
-    information, see
-    <link xlink:href="https://www.olcf.ornl.gov/center-projects/adios/"/>.
+    scientists to describe the data in their code that may need to be written,
+    read, or processed outside of the running simulation. For more information,
+    see <link xlink:href="https://www.olcf.ornl.gov/center-projects/adios/"/>.
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> adios</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>. For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1184,12 +1222,13 @@
     </listitem>
    </itemizedlist>
    <para>
-    Replace <replaceable>MPI_FLAVOR</replaceable> with one of the supported
-    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
+    Replace <replaceable>MPI_FLAVOR</replaceable> with one of the supported MPI
+    flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-lib-hdf5">
-   <!-- href="https://fate.novell.com/321710" -->
+<!-- href="https://fate.novell.com/321710" -->
    <title>HDF5 HPC library &mdash; model, library, file format for storing and managing data</title>
    <para>
     HDF5 is a data model, library, and file format for storing and managing
@@ -1208,15 +1247,15 @@
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> hdf5</screen>
    <para>
-    When an MPI flavor is loaded, the MPI version of this module can be
-    loaded by:
+    When an MPI flavor is loaded, the MPI version of this module can be loaded
+    by:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> phpdf5</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>. For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1279,27 +1318,29 @@
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
-    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported MPI
+    flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     For general information about Lmod and modules, see
-    <xref linkend="sec-compute-lmod"/>.
+    <xref
+     linkend="sec-compute-lmod"/>.
    </para>
   </sect2>
+
   <sect2 xml:id="sec2-lib-netcdf">
-   <!-- href="https://fate.novell.com/321719" -->
+<!-- href="https://fate.novell.com/321719" -->
    <title>NetCDF HPC library &mdash; implementation of self-describing data formats</title>
    <para>
     The NetCDF software libraries for C, C++, Fortran, and Perl are a set of
     software libraries and self-describing, machine-independent data formats
-    that support the creation, access, and sharing of array-oriented
-    scientific data.
+    that support the creation, access, and sharing of array-oriented scientific
+    data.
    </para>
    <bridgehead renderas="sect5"><literal>netcdf</literal> Packages</bridgehead>
    <para>
-    The packages with names starting with <literal>netcdf</literal> provide
-    C bindings for the NetCDF API. These are available with and without MPI
+    The packages with names starting with <literal>netcdf</literal> provide C
+    bindings for the NetCDF API. These are available with and without MPI
     support.
    </para>
    <para>
@@ -1309,16 +1350,15 @@
    </para>
    <para>
     The MPI variant becomes available when the MPI module is loaded. Both
-    variants require loading a compiler toolchain module beforehand. To
-    load the highest version of the non-MPI <literal>netcdf</literal> module,
-    run:
+    variants require loading a compiler toolchain module beforehand. To load
+    the highest version of the non-MPI <literal>netcdf</literal> module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> netcdf</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>,
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>, For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1361,13 +1401,13 @@
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
-    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported MPI
+    flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
-   <bridgehead renderas="sect5"><literal>netcdf-cxx</literal> Packages</bridgehead>
+   <bridgehead renderas="sect5"><literal>netcdf-cxx</literal>
+    Packages</bridgehead>
    <para>
-    <package>netcdf-cxx4</package> provides a C++ binding for the NetCDF
-    API.
+    <package>netcdf-cxx4</package> provides a C++ binding for the NetCDF API.
    </para>
    <para>
     This module requires loading a compiler toolchain module beforehand. To
@@ -1376,7 +1416,8 @@
 <screen>module load <replaceable>TOOLCHAIN</replaceable> netcdf-cxx4</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
+    <xref
+     linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -1398,10 +1439,11 @@
      </para>
     </listitem>
    </itemizedlist>
-   <bridgehead renderas="sect5"><literal>netcdf-fortran</literal> Packages</bridgehead>
+   <bridgehead renderas="sect5"><literal>netcdf-fortran</literal>
+    Packages</bridgehead>
    <para>
-    The <literal>netcdf-fortran</literal> packages provide Fortran bindings
-    for the NetCDF API, with and without MPI support.
+    The <literal>netcdf-fortran</literal> packages provide Fortran bindings for
+    the NetCDF API, with and without MPI support.
    </para>
    <para>
     There are serial and MPI variants of this library available. All flavors
@@ -1410,9 +1452,9 @@
    </para>
    <para>
     The MPI variant becomes available when the MPI module is loaded. Both
-    variants require loading a compiler toolchain module beforehand. To
-    load the highest version of the non-MPI <literal>netcdf-fortran</literal> module,
-    run:
+    variants require loading a compiler toolchain module beforehand. To load
+    the highest version of the non-MPI <literal>netcdf-fortran</literal>
+    module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> netcdf-fortran</screen>
    <para>
@@ -1421,9 +1463,9 @@
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> netcdf-fortran</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>,
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>, For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1461,57 +1503,67 @@
     </listitem>
    </itemizedlist>
   </sect2>
+
   <sect2 xml:id="sec2-lib-pnetcdf">
    <title>HPC flavor of <literal>pnetcdf</literal> has been added</title>
    <para>
-   NetCDF is a set of software libraries and self-describing,
-   machine-independent data formats that support the creation, access,
-   and sharing of array-oriented scientific data.
+    NetCDF is a set of software libraries and self-describing,
+    machine-independent data formats that support the creation, access, and
+    sharing of array-oriented scientific data.
    </para>
    <para>
-   Parallel netCDF (<literal>PnetCDF</literal>) is a library providing
-   high-performance I/O while still maintaining file-format compatibility
-   with NetCDF by Unidata.
+    Parallel netCDF (<literal>PnetCDF</literal>) is a library providing
+    high-performance I/O while still maintaining file-format compatibility with
+    NetCDF by Unidata.
    </para>
    <para>
-   The package is available for the MPI Flavors: Open MPI 2 and 3, MVAPICH2 and MPICH.
+    The package is available for the MPI Flavors: Open MPI 2 and 3, MVAPICH2
+    and MPICH.
    </para>
    <para>
     To load the highest available serial version of this module, run:
    </para>
-   <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> pnetcdf</screen>
+<screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> pnetcdf</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>. For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of MPI master packages:
    </para>
    <itemizedlist>
-    <listitem><para>
+    <listitem>
+     <para>
       <package>libpnetcdf-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
-     </para></listitem>
-    <listitem><para>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       <package>pnetcdf-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
-     </para></listitem>
-    <listitem><para>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       <package>pnetcdf-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</package>
-     </para></listitem>
+     </para>
+    </listitem>
    </itemizedlist>
    <para>
-    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
-    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported MPI
+    flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
  </sect1>
- <sect1  xml:id="sec1-MPI-libs">
+ <sect1 xml:id="sec1-MPI-libs">
   <title>MPI libraries</title>
+
   <para>
    Three different implementation of the Message Passing Interface (MPI)
    standard are provided standard with the HPC module:
   </para>
+
   <itemizedlist>
    <listitem>
     <para>
@@ -1524,78 +1576,103 @@
     </para>
    </listitem>
    <listitem>
-     <para>
-      MPICH
+    <para>
+     MPICH
     </para>
    </listitem>
   </itemizedlist>
+
   <para>
    These packages have been built with full environment module support (LMOD).
   </para>
+
   <para>
    The following packages are available:
   </para>
+
   <itemizedlist>
    <listitem>
-    <para>For Open MPI:</para>
+    <para>
+     For Open MPI:
+    </para>
     <itemizedlist>
      <listitem>
-      <para>user programs: <literal>openmpi3-gnu-hpc</literal> and
-      <literal>openmpi4-gnu-hpc</literal>
+      <para>
+       user programs: <literal>openmpi3-gnu-hpc</literal> and
+       <literal>openmpi4-gnu-hpc</literal>
       </para>
      </listitem>
      <listitem>
-      <para>shared libraries: <literal>libopenmpi3-gnu-hpc</literal> and
-      <literal>libopenmpi4-gnu-hpc</literal>
+      <para>
+       shared libraries: <literal>libopenmpi3-gnu-hpc</literal> and
+       <literal>libopenmpi4-gnu-hpc</literal>
       </para>
      </listitem>
      <listitem>
-      <para>development libraries, headers and tools required for building:
-      <literal>openmpi3-gnu-hpc-devel</literal> and
-      <literal>openmpi4-gnu-hpc-devel</literal></para>
+      <para>
+       development libraries, headers and tools required for building:
+       <literal>openmpi3-gnu-hpc-devel</literal> and
+       <literal>openmpi4-gnu-hpc-devel</literal>
+      </para>
      </listitem>
      <listitem>
-      <para>documentation: <literal>openmpi3-gnu-hpc-docs</literal> and
-      <literal>openmpi4-gnu-hpc-docs</literal>.
+      <para>
+       documentation: <literal>openmpi3-gnu-hpc-docs</literal> and
+       <literal>openmpi4-gnu-hpc-docs</literal>.
       </para>
      </listitem>
     </itemizedlist>
    </listitem>
    <listitem>
-    <para>For MVAPICH2</para>
+    <para>
+     For MVAPICH2
+    </para>
     <itemizedlist>
      <listitem>
-      <para>user programs and libraries:
-      <literal>mvapich2-gnu-hpc</literal></para>
-     </listitem>
-     <listitem>
-      <para>development libraries, headers and tools for building:
-      <literal>mvapich2-gnu-hpc-devel</literal></para>
-     </listitem>
-     <listitem>
-      <para>documentation: <literal>mvapich2-gnu-hpc-doc</literal></para>
-     </listitem>
-    </itemizedlist>
-    <para>For MPICH:</para>
-    <itemizedlist>
-     <listitem>
-      <para>user programs and libraries: <literal>mpich-gnu-hpc</literal>
+      <para>
+       user programs and libraries: <literal>mvapich2-gnu-hpc</literal>
       </para>
      </listitem>
      <listitem>
-      <para>development libraries, headers and tools for building:
-      <literal>mpich-gnu-hpc-devel</literal></para>
+      <para>
+       development libraries, headers and tools for building:
+       <literal>mvapich2-gnu-hpc-devel</literal>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       documentation: <literal>mvapich2-gnu-hpc-doc</literal>
+      </para>
+     </listitem>
+    </itemizedlist>
+    <para>
+     For MPICH:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       user programs and libraries: <literal>mpich-gnu-hpc</literal>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       development libraries, headers and tools for building:
+       <literal>mpich-gnu-hpc-devel</literal>
+      </para>
      </listitem>
     </itemizedlist>
    </listitem>
   </itemizedlist>
+
   <para>
-   The different MPI implementations and versions are independent of each
-   other can be installed in parallel.
+   The different MPI implementations and versions are independent of each other
+   can be installed in parallel.
   </para>
+
   <para>
    Use environment modules to pick the version to use:
   </para>
+
   <itemizedlist>
    <listitem>
     <para>
@@ -1617,47 +1694,52 @@
    </listitem>
    <listitem>
     <para>
-      For MPICH:
+     For MPICH:
     </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> mpich</screen>
    </listitem>
   </itemizedlist>
-   <para>
-    For information on the toolchain to load, check: <xref linkend="sec-compiler"/>.
-   </para>
- </sect1>
 
+  <para>
+   For information on the toolchain to load, check:
+   <xref
+    linkend="sec-compiler"/>.
+  </para>
+ </sect1>
  <sect1 xml:id="sec1-packages-profiling-benchmark">
   <title>Profiling and benchmarking libraries and tools</title>
+
   <para>
    Performance optimization plays an important role in HPC. That applications
-   are run across multiple cluster nodes poses an additional challenge.
-   &shpca; provides a number of tools for profiling MPI applications and
-   benchmarking MPI performance.
+   are run across multiple cluster nodes poses an additional challenge. &shpca;
+   provides a number of tools for profiling MPI applications and benchmarking
+   MPI performance.
   </para>
+
   <sect2 xml:id="sec2-tool-imb">
-   <!-- href="https://fate.novell.com/324155" -->
+<!-- href="https://fate.novell.com/324155" -->
    <title>IMB &mdash; Intel&thrdmrk; MPI benchmarks</title>
    <para>
     The Intel&thrdmrk; MPI Benchmarks package provides a set of elementary
     benchmarks that conform to the MPI-1, MPI-2, and MPI-3 standards. You can
     run all of the supported benchmarks, or a subset specified in the command
-    line, using a single executable file. Use command-line parameters to specify
-    various settings, such as time measurement, message lengths, and selection
-    of communicators. For details, see the Intel&thrdmrk; MPI Benchmarks User's
-    Guide located at:
-    <link xlink:href="https://software.intel.com/en-us/imb-user-guide"/>.
+    line, using a single executable file. Use command-line parameters to
+    specify various settings, such as time measurement, message lengths, and
+    selection of communicators. For details, see the Intel&thrdmrk; MPI
+    Benchmarks User's Guide located at:
+    <link
+     xlink:href="https://software.intel.com/en-us/imb-user-guide"/>.
    </para>
-      <para>
+   <para>
     For the IMB binaries to be found, a compiler toolchain and an MPI flavor
     need to be loaded beforehand. To load this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> imb</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>. For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <itemizedlist>
     <listitem>
@@ -1667,13 +1749,14 @@
     </listitem>
    </itemizedlist>
   </sect2>
+
   <sect2 xml:id="sec2-lib-papi">
-   <!-- href="https://fate.novell.com/321720" -->
+<!-- href="https://fate.novell.com/321720" -->
    <title>PAPI HPC library &mdash; consistent interface for hardware performance counters</title>
    <para>
-    PAPI (package <package>papi</package>) provides a tool with a
-    consistent interface and methodology for use of the performance counter
-    hardware found in most major microprocessors.
+    PAPI (package <package>papi</package>) provides a tool with a consistent
+    interface and methodology for use of the performance counter hardware found
+    in most major microprocessors.
    </para>
    <para>
     This package works with all compiler toolchains and does not require a
@@ -1683,7 +1766,8 @@
 <screen>module load <replaceable>TOOLCHAIN</replaceable> papi</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
+    <xref
+     linkend="sec-compiler"/>.
    </para>
    <para>
     List of master packages:
@@ -1702,32 +1786,32 @@
    </itemizedlist>
    <para>
     For general information about Lmod and modules, see
-    <xref linkend="sec-compute-lmod"/>.
+    <xref
+     linkend="sec-compute-lmod"/>.
    </para>
   </sect2>
 
   <sect2 xml:id="sec2-lib-mpip">
-   <!-- href="https://fate.novell.com/321721" -->
+<!-- href="https://fate.novell.com/321721" -->
    <title>mpiP &mdash; lightweight MPI profiling library</title>
    <para>
-    mpiP is a lightweight profiling library for MPI applications.
-    Because it only collects statistical information about MPI
-    functions, mpiP generates considerably less overhead and much
-    less data than tracing tools. All the information captured
-    by mpiP is task-local. It only uses communication during
-    report generation, typically at the end of the experiment,
-    to merge results from all of the tasks into one output file.
+    mpiP is a lightweight profiling library for MPI applications. Because it
+    only collects statistical information about MPI functions, mpiP generates
+    considerably less overhead and much less data than tracing tools. All the
+    information captured by mpiP is task-local. It only uses communication
+    during report generation, typically at the end of the experiment, to merge
+    results from all of the tasks into one output file.
    </para>
    <para>
-    For this library a compiler toolchain and and MPI flavor
-    needs to be loaded beforehand. To load this module, run:
+    For this library a compiler toolchain and and MPI flavor needs to be loaded
+    beforehand. To load this module, run:
    </para>
 <screen>module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> mpip</screen>
    <para>
     For information on the toolchain to load, see:
-    <xref linkend="sec-compiler"/>.
-    For information on available MPI flavors, see:
-    <xref linkend="sec1-MPI-libs"/>.
+    <xref
+     linkend="sec-compiler"/>. For information on available MPI
+    flavors, see: <xref linkend="sec1-MPI-libs"/>.
    </para>
    <para>
     List of master packages:
@@ -1750,8 +1834,8 @@
     </listitem>
    </itemizedlist>
    <para>
-    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported
-    MPI flavors described in <xref linkend="sec1-MPI-libs"/>.
+    <replaceable>MPI_FLAVOR</replaceable> must be one of the supported MPI
+    flavors described in <xref linkend="sec1-MPI-libs"/>.
    </para>
   </sect2>
  </sect1>

--- a/xml/deployment.xml
+++ b/xml/deployment.xml
@@ -51,7 +51,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-deployment-slurm">
-  <title>Slurm configuration</title>
+  <title>&slurm; configuration</title>
   <para>
    A paragraph of text.
   </para>

--- a/xml/hardware.xml
+++ b/xml/hardware.xml
@@ -64,8 +64,8 @@
    <emphasis>lstopo</emphasis> allows the user to obtain the topology
    of a machine or convert topology information obtained on a remote
    machine into one of several output formats. In graphical mode (X11),
-   it displays the topology in a window, several other output formats
-   are available as well , including plain text, PDF, PNG, SVG and FIG.
+   it displays the topology in a window. Several other output formats
+   are available as well, including plain text, PDF, PNG, SVG and FIG.
    For more information, see the man pages provided by
    <literal>hwloc</literal> and <literal>lstopo</literal>.
   </para>

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -19,7 +19,7 @@
     &product; comes with a number of preconfigured system roles for HPC. These
     roles provide a set of preselected packages typical for the specific role,
     as well as an installation workflow that will configure the system to make
-    the best use of system resource based on a typical role use case.
+    the best use of system resources based on a typical use case of a role.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -111,7 +111,7 @@
        </listitem>
        <listitem>
         <para>
-         Does not create a separate home partition
+         Does not create a separate <literal>/home</literal> partition
         </para>
        </listitem>
        <listitem>
@@ -150,7 +150,8 @@
    </para>
    <para>
     The Environment Module <literal>Lmod</literal> will be installed for all
-    roles. It is required at build time and run time of the system.
+    roles. It is required at build time and run time of the system. For more
+    information, see <xref linkend="sec-compute-lmod"/>.
    </para>
    <para>
     All libraries specifically built for HPC will be installed under
@@ -167,7 +168,8 @@
     From the Ganglia monitoring system, the data collector
     <package>ganglia-gmod</package> is installed for every role, while the
     data aggregator <package>ganglia-gmetad</package> needs to be installed
-    manually on the system which is expected to collect the data.
+    manually on the system which is expected to collect the data. For more
+    information, see <xref linkend="sec-monitoring-ganglia"/>.
    </para>
    <para>
     The system roles are only available for new installations of &product;.

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -66,7 +66,7 @@
        </listitem>
        <listitem>
         <para>
-         Installs a controller for the Slurm workload manager
+         Installs a controller for the &slurm; workload manager
         </para>
        </listitem>
        <listitem>
@@ -106,7 +106,7 @@
        </listitem>
        <listitem>
         <para>
-         Installs a client for the Slurm workload manager
+         Installs a client for the &slurm; workload manager
         </para>
        </listitem>
        <listitem>

--- a/xml/monitoring.xml
+++ b/xml/monitoring.xml
@@ -163,15 +163,15 @@
   <para>
    <systemitem class="daemon">rasdaemon</systemitem> is a RAS
    (Reliability, Availability and Serviceability) logging tool. It records
-   memory errors using EDAC tracing events. EDAC drivers in the Linux kernel
-   handle detection of ECC errors from memory controllers.
+   memory errors using EDAC (Error Detection And Correction) tracing events.
+   EDAC drivers in the Linux kernel handle detection of ECC (Error Correction
+   Code) errors from memory controllers.
   </para>
   <para>
    <systemitem class="daemon">rasdaemon</systemitem> can be used on large
-   memory systems to
-   track, record and localize memory errors and how they evolve over time
-   to detect hardware degradation. Furthermore, it can be used to localize
-   a faulty DIMM on the board.
+   memory systems to track, record and localize memory errors and how they
+   evolve over time to detect hardware degradation. Furthermore, it can be used
+   to localize a faulty DIMM on the motherboard.
   </para>
   <para>
    To check whether the EDAC drivers are loaded, execute:
@@ -208,8 +208,8 @@
    description, create a file with an arbitrary name in the directory
    <filename>/etc/ras/dimm_labels.d/</filename>. The format is:
   </para>
-  <screen>Vendor: <replaceable>VENDOR-NAME</replaceable>
-  Model: <replaceable>MODEL-NAME</replaceable>
+<screen>Vendor: <replaceable>MOTHERBOARD-VENDOR-NAME</replaceable>
+Model: <replaceable>MOTHERBOARD-MODEL-NAME</replaceable>
   <replaceable>LABEL</replaceable>: <replaceable>MC</replaceable>.<replaceable>TOP</replaceable>.<replaceable>MID</replaceable>.<replaceable>LOW</replaceable></screen>
  </sect1>
 </chapter>

--- a/xml/monitoring.xml
+++ b/xml/monitoring.xml
@@ -176,7 +176,7 @@
   <para>
    To check whether the EDAC drivers are loaded, execute:
   </para>
-<screen>ras-mc-ctl --status</screen>
+<screen>&prompt;ras-mc-ctl --status</screen>
   <para>
    The command should return <literal>ras-mc-ctl: drivers are
    loaded</literal>. If it indicates that the drivers are not loaded, EDAC
@@ -191,17 +191,17 @@
    <filename>/var/log/messages</filename> and to an internal database. A
    summary of the stored errors can be obtained with:
   </para>
-<screen>ras-mc-ctl --summary</screen>
+<screen>&prompt;ras-mc-ctl --summary</screen>
   <para>
    The errors stored in the database can be viewed with:
   </para>
-<screen>ras-mc-ctl --errors</screen>
+<screen>&prompt;ras-mc-ctl --errors</screen>
   <para>
    Optionally, you can load the DIMM labels silk-screened on the system
    board to more easily identify the faulty DIMM. To do so, before starting
    <systemitem class="daemon">rasdaemon</systemitem>, run:
   </para>
-  <screen>systemctl start ras-mc-ctl start</screen>
+<screen>&prompt;systemctl start ras-mc-ctl start</screen>
   <para>
    For this to work, you need to set up a layout description for the board.
    There are no descriptions supplied by default. To add a layout

--- a/xml/monitoring.xml
+++ b/xml/monitoring.xml
@@ -57,8 +57,9 @@
    </listitem>
    <listitem>
     <para>
-     external processes (for example, using 'expect' scripts for telnet,
-     ssh, or ipmi-sol connections)
+     external processes (for example, using <command>expect</command> scripts
+     for <command>telnet</command>, <command>ssh</command>, or
+     <command>ipmi-sol</command> connections)
     </para>
    </listitem>
   </itemizedlist>
@@ -154,7 +155,7 @@
     start</command> and make sure it is started automatically after a
     reboot: <command>systemctl enable apache2</command>. The Ganglia Web
     interface should be accessible from
-    <literal>http://<replaceable>MANAGEMENT_SERVER</replaceable>/ganglia-web</literal>.
+    <literal>http://<replaceable>MANAGEMENT_SERVER</replaceable>/ganglia</literal>.
    </para>
   </sect2>
  </sect1>

--- a/xml/monitoring.xml
+++ b/xml/monitoring.xml
@@ -139,7 +139,7 @@
    <para>
     When using the Btrfs file system, the monitoring data will be lost after
     a rollback and the service <systemitem class="daemon">gmetad</systemitem>.
-    To be able to start it again, either install the package
+    To be fix this issue, either install the package
     <package>ganglia-gmetad-skip-bcheck</package> or create the file
     <filename>/etc/ganglia/no_btrfs_check</filename>.
    </para>
@@ -148,13 +148,13 @@
    <title>Using the Ganglia Web interface</title>
    <para>
     Install <package>ganglia-web</package> on the management server.
-    Depending on which PHP version is used (default is PHP 5), enable it in
-    Apache2: <command>a2enmod php5</command> or <command>a2enmod
+    Depending on which PHP version is used (the default is PHP 7), enable it in
+    Apache2: <command>a2enmod php7</command> or <command>a2enmod
     php7</command>. Then start Apache2 on this machine: <command>rcapache2
     start</command> and make sure it is started automatically after a
     reboot: <command>systemctl enable apache2</command>. The Ganglia Web
     interface should be accessible from
-    <literal>http://<replaceable>MANAGEMENT_SERVER</replaceable>/ganglia</literal>.
+    <literal>http://<replaceable>MANAGEMENT_SERVER</replaceable>/ganglia-web</literal>.
    </para>
   </sect2>
  </sect1>
@@ -162,10 +162,9 @@
   <title>rasdaemon &mdash; utility to log RAS error tracings</title>
   <para>
    <systemitem class="daemon">rasdaemon</systemitem> is a RAS
-   (Reliability, Availability and
-   Serviceability) logging tool. It records memory errors using the EDAC
-   tracing events. EDAC drivers in the Linux kernel handle detection of ECC
-   errors from memory controllers.
+   (Reliability, Availability and Serviceability) logging tool. It records
+   memory errors using EDAC tracing events. EDAC drivers in the Linux kernel
+   handle detection of ECC errors from memory controllers.
   </para>
   <para>
    <systemitem class="daemon">rasdaemon</systemitem> can be used on large

--- a/xml/monitoring.xml
+++ b/xml/monitoring.xml
@@ -163,7 +163,7 @@
   <para>
    <systemitem class="daemon">rasdaemon</systemitem> is a RAS
    (Reliability, Availability and Serviceability) logging tool. It records
-   memory errors using EDAC (Error Detection And Correction) tracing events.
+   memory errors using EDAC (Error Detection and Correction) tracing events.
    EDAC drivers in the Linux kernel handle detection of ECC (Error Correction
    Code) errors from memory controllers.
   </para>

--- a/xml/preface_hpc-guide.xml
+++ b/xml/preface_hpc-guide.xml
@@ -59,7 +59,7 @@
    <term><xref linkend="part-slurm"/></term>
    <listitem>
     <para>
-        The Slurm scheduler.
+        The &slurm; scheduler.
     </para>
    </listitem>
   </varlistentry>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -25,6 +25,11 @@
 <!ENTITY sle "&suse; Linux Enterprise">
 <!ENTITY shpca "&slea; &hpca;">
 
+<!ENTITY slurm "Slurm">
+<!ENTITY mrsh "mrsh">
+<!ENTITY munge "MUNGE">
+
+
 
 <!-- Prompts used in 15 SP2 RN -->
 <!ENTITY prompt           "<prompt xmlns='http://docbook.org/ns/docbook'># </prompt>">

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -19,7 +19,7 @@
     HPC clusters usually consist of a small set of identical compute
     nodes. Each cluster may consist of a mere handful of machines, up to
     thousands. Managing the compute nodes of a cluster may be challenging. This
-    chapter descibes a number of tools which aid this task.
+    chapter describes a number of tools which aid this task.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -78,7 +78,7 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
   <sect2 xml:id="sec-nodeattr">
    <title>Nodeattr usage</title>
    <para>
-    The command line utility <command>nodeaddr</command> can be used to query data
+    The command line utility <command>nodeattr</command> can be used to query data
     in the genders file. When the genders file is replicated on all nodes, a qery
     can be done wihtout network access. It can be called as follows:
    </para>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -82,9 +82,9 @@ nodenames[A-B]          attr[=value],attr[=value],...
    <para>
     The command line utility <command>nodeaddr</command> can be used to query data
     in the genders file. When the genders file is replicated on all nodes, a qery
-    can be done wihtout network access. It can be called like followed
+    can be done wihtout network access. It can be called as follows:
    </para>
-<screen>nodeattr [-q | -n | -s] [-r] attr[=val]</screen>
+<screen>&prompt;nodeattr [-q | -n | -s] [-r] attr[=val]</screen>
   <para>
    where <literal>-q</literal> is the default option and prints a list nodes
    with <literal>attr[=val]</literal> as the host range.
@@ -106,15 +106,15 @@ nodenames[A-B]          attr[=value],attr[=value],...
     When <command>nodeattr</command> is called with the <literal>-l</literal>
     parameter, as follows:
   </para>
-<screen>nodeattr -l [node]</screen>
+<screen>&prompt;nodeattr -l [node]</screen>
   <para>
    all attributes for a particular node are printed out. If no node
    paramteter is is given, all attributes of the local node are printed out.
   </para>
   <para>
-   With the command
+   With the command:
   </para>
-<screen>nodeattr [-f genders] -k</screen>
+<screen>&prompt;nodeattr [-f genders] -k</screen>
   <para>
    a syntax check of the genders database is performed, where with the switch
    <literal>-f</literal> an alternative datanbase location can be specified.
@@ -184,7 +184,7 @@ nodenames[A-B]          attr[=value],attr[=value],...
    the installation of plugins with conflicting command options. To install one
    of the plugins, run:
   </para>
-<screen>zypper in pdsh-<replaceable>PLUGIN_NAME</replaceable></screen>
+<screen>&prompt;zypper in pdsh-<replaceable>PLUGIN_NAME</replaceable></screen>
   <para>
    For more information, see the <command>man</command> page <command>pdsh</command>.
   </para>
@@ -234,11 +234,11 @@ nodenames[A-B]          attr[=value],attr[=value],...
   <para>
    After configuring PowerMan, start its service by:
   </para>
-  <screen>systemctl start powerman.service</screen>
+<screen>&prompt;systemctl start powerman.service</screen>
   <para>
    To start PowerMan automatically after every boot, run:
   </para>
-  <screen>systemctl enable powerman.service</screen>
+<screen>&prompt;systemctl enable powerman.service</screen>
   <para>
    Optionally, PowerMan can connect to a remote PowerMan instance. To
    enable this, add the option <literal>listen</literal> to
@@ -258,16 +258,15 @@ nodenames[A-B]          attr[=value],attr[=value],...
   <para>
    <emphasis>MUNGE</emphasis> allows for secure communications between
    different machines which share the same secret key. The most common
-   usecase is the <emphasis>Slurm</emphasis> workload manager, which
+   use case is the <emphasis>Slurm</emphasis> workload manager, which
    uses MUNGE for the encryption of its messages. Another use case is
-   authentication for the parallel shell
-   <emphasis>mrsh</emphasis>.
+   authentication for the parallel shell <emphasis>mrsh</emphasis>.
   </para>
   <sect2>
    <title>Setting up MUNGE authentication</title>
    <para>
     MUNGE uses UID/GID values to uniquely identify and authenticate users. Thus,
-    you must take care that users who will authenicate across a network have
+    you must take care that users who will authenticate across a network have
     unified UIDs and GIDs.
    </para>
    <para>
@@ -276,38 +275,46 @@ nodenames[A-B]          attr[=value],attr[=value],...
    </para>
    <para>
     MUNGE is installed with the command <command>zypper in munge</command>.
-    This will install all packages required at runtime. A
-    <package>munge-devel</package> package is available to build applications
-    that require <emphasis>munge</emphasis> authentication.
+    This will install all packages required at runtime. The package
+    <package>munge-devel</package> can be used to build applications that
+    require <emphasis>munge</emphasis> authentication.
    </para>
    <para>
     When installing the <package>munge</package> package, a new key is generated
-    on every system. However, this MUNGE key must be uniform across the entire
-    cluster. Therefore, the key from one system needs to be copied in a secure
-    way to all other nodes in the cluster. Care must be taken that the key is
-    only readable by the <literal>munge</literal> user (permissions mask
+    on every system. However, the entire cluster needs to use the same MUNGE
+    key. Therefore, you must copy the MUNGE key from the first system to all
+    te other nodes in the cluster, in a secure way. Care must be taken that the
+    key is only readable by the <literal>munge</literal> user (permissions mask
     <literal>0400</literal>).
    </para>
    <para>
-    <emphasis>pdsh</emphasis> (with ssh) may be used to do this:
+    <emphasis>pdsh</emphasis> (with SSH) may be used to do this:
    </para>
    <para>
     Check permissions, owner and file type of the key file located under
     <filename>/etc/munge/munge.key</filename> on the local system:
    </para>
-<screen># stat --format "%F %a %G %U %n" /etc/munge/munge.key</screen>
-   <para>The settings should be:</para>
+<screen>&prompt;stat --format "%F %a %G %U %n" /etc/munge/munge.key</screen>
+   <para>
+    The settings should be:
+   </para>
 <screen>400 regular file munge munge /etc/munge/munge.key</screen>
-   <para>Get md5sum of munge.key:</para>
-<screen># md5sum /etc/munge/munge.key</screen>
-   <para>Copy key to list of nodes:</para>
-<screen># pdcp -R ssh -w &lt;hostlist&gt; /etc/munge/munge.key
-   /etc/munge/munge.key </screen>
-   <para>Check key settings in remote host:</para>
-<screen>pdsh -R ssh -w &lt;hostlist&gt; stat --format \"%F %a %G %U %n\"
-/etc/munge/munge.key
-pdsh -R ssh -w &lt;hostlist&gt; md5sum /etc/munge/munge.key</screen>
-   <para>Make sure that they match.</para>
+   <para>
+    Calculate the MD5 sum of <filename>munge.key</filename>:
+   </para>
+<screen>&prompt;md5sum /etc/munge/munge.key</screen>
+   <para>
+    Copy the key to the listed nodes:
+   </para>
+<screen>&prompt;pdcp -R ssh -w <replaceable>HOSTLIST</replaceable> /etc/munge/munge.key /etc/munge/munge.key</screen>
+   <para>
+    Check the key settings on the remote host:
+   </para>
+<screen>&prompt;pdsh -R ssh -w <replaceable>HOSTLIST</replaceable> stat --format \"%F %a %G %U %n\" /etc/munge/munge.key
+&prompt;pdsh -R ssh -w <replaceable>HOSTLIST</replaceable> md5sum /etc/munge/munge.key</screen>
+   <para>
+    Make sure that they match.
+   </para>
   </sect2>
   <sect2>
    <title>Enabling and starting MUNGE</title>
@@ -321,8 +328,8 @@ pdsh -R ssh -w &lt;hostlist&gt; md5sum /etc/munge/munge.key</screen>
     To start the service and make sure it is started after every reboot, on each
     node, run:
    </para>
-<screen>systemctl enable munge.service
-systemctl start munge.service</screen>
+<screen>&prompt;systemctl enable munge.service
+&prompt;systemctl start munge.service</screen>
     <para>
      To perform the same on multiple nodes, you can also use
      <command>pdsh</command>.
@@ -373,19 +380,19 @@ systemctl start munge.service</screen>
    has been successfully started, enable and start <command>mrlogin</command>
    on each machine on which the user will log in:
   </para>
-  <screen>systemctl enable mrlogind.socket mrshd.socket
-systemctl start mrlogind.socket mrshd.socket</screen>
+<screen>&prompt;systemctl enable mrlogind.socket mrshd.socket
+&prompt;systemctl start mrlogind.socket mrshd.socket</screen>
   <para>
    To start mrsh support at boot, run:
   </para>
-  <screen>systemctl enable munge.service
-systemctl enable mrlogin.service</screen>
+<screen>&prompt;systemctl enable munge.service
+&prompt;systemctl enable mrlogin.service</screen>
   <para>
    We do not recommend using <emphasis>mrsh</emphasis> when logged in as the
    user <systemitem class="username">root</systemitem>. This is disabled by
    default. To enable it regardless, run:
   </para>
-  <screen>echo "mrsh" &gt;&gt; /etc/securetty
-  echo "mrlogin" &gt;&gt; /etc/securetty</screen>
+  <screen>&prompt;echo "mrsh" &gt;&gt; /etc/securetty
+&prompt;echo "mrlogin" &gt;&gt; /etc/securetty</screen>
  </sect1>
 </chapter>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -110,12 +110,12 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
    paramteter is is given, all attributes of the local node are printed out.
   </para>
   <para>
-   With the command:
+   To perform a syntax check of the genders database, run:
   </para>
 <screen>&prompt;nodeattr [-f genders] -k</screen>
   <para>
-   a syntax check of the genders database is performed, where with the switch
-   <literal>-f</literal> an alternative datanbase location can be specified.
+   To specify an alternative database location, use the option
+   <literal>-f</literal>.
   </para>
  </sect2>
   
@@ -156,7 +156,7 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
    <command>pdsh</command> can use a <filename>machines</filename> file
    (<filename>/etc/pdsh/machines</filename>), <command>dsh</command> (Dancer's
    shell)-style groups or netgroups. Also, it can target nodes based on the
-   currently running Slurm jobs.
+   currently running &slurm; jobs.
   </para>
   <para>
    The different ways to select target hosts are realized by modules. Some
@@ -251,35 +251,34 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
   </important>
  </sect1>
  <sect1 xml:id="sec-remote-munge">
-  <title>MUNGE authentication</title>
+  <title>&munge; authentication</title>
   <para>
-   <emphasis>MUNGE</emphasis> allows for secure communications between
-   different machines which share the same secret key. The most common
-   use case is the <emphasis>Slurm</emphasis> workload manager, which
-   uses MUNGE for the encryption of its messages. Another use case is
-   authentication for the parallel shell <emphasis>mrsh</emphasis>.
+   &munge; allows for secure communications between different machines which
+   share the same secret key. The most common use case is the &slurm; workload
+   manager, which uses &munge; for the encryption of its messages. Another use
+   case is authentication for the parallel shell mrsh.
   </para>
   <sect2>
-   <title>Setting up MUNGE authentication</title>
+   <title>Setting up &munge; authentication</title>
    <para>
-    MUNGE uses UID/GID values to uniquely identify and authenticate users. Thus,
+    &munge; uses UID/GID values to uniquely identify and authenticate users. Thus,
     you must take care that users who will authenticate across a network have
     unified UIDs and GIDs.
    </para>
    <para>
-    MUNGE credentials have a limited time-to-live, so you must ensure that the
+    &munge; credentials have a limited time-to-live, so you must ensure that the
     time is synchronized across the entire cluster.
    </para>
    <para>
-    MUNGE is installed with the command <command>zypper in munge</command>.
+    &munge; is installed with the command <command>zypper in munge</command>.
     This will install all packages required at runtime. The package
     <package>munge-devel</package> can be used to build applications that
     require <emphasis>munge</emphasis> authentication.
    </para>
    <para>
     When installing the <package>munge</package> package, a new key is generated
-    on every system. However, the entire cluster needs to use the same MUNGE
-    key. Therefore, you must copy the MUNGE key from the first system to all
+    on every system. However, the entire cluster needs to use the same &munge;
+    key. Therefore, you must copy the &munge; key from the first system to all
     te other nodes in the cluster, in a secure way. Care must be taken that the
     key is only readable by the <literal>munge</literal> user (permissions mask
     <literal>0400</literal>).
@@ -314,10 +313,10 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
    </para>
   </sect2>
   <sect2>
-   <title>Enabling and starting MUNGE</title>
+   <title>Enabling and starting &munge;</title>
    <para>
     <systemitem class="daemon">munged</systemitem> needs to be run on all nodes
-    where MUNGE authentication will take place. If MUNGE is used for
+    where &munge; authentication will take place. If &munge; is used for
     authentication across the network, it needs to run on each side of the
     communications link.
    </para>
@@ -334,10 +333,10 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-remote-mrsh">
-  <title>mrsh/mrlogin &mdash; remote login using MUNGE authentication</title>
+  <title>mrsh/mrlogin &mdash; remote login using &munge; authentication</title>
   <para>
    <emphasis>mrsh</emphasis> is a set of remote shell programs using the
-   <emphasis>MUNGE</emphasis> authentication system instead of reserved ports
+   <emphasis>&munge;</emphasis> authentication system instead of reserved ports
    for security.
   </para>
   <para>
@@ -372,8 +371,8 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
   </itemizedlist>
   <para>
    To set up a cluster of machines allowing remote login from each other,
-   first follow the instructions for setting up and starting MUNGE
-   authentication in <xref linkend="sec-remote-munge"/>. After the MUNGE service
+   first follow the instructions for setting up and starting &munge;
+   authentication in <xref linkend="sec-remote-munge"/>. After the &munge; service
    has been successfully started, enable and start <command>mrlogin</command>
    on each machine on which the user will log in:
   </para>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -49,11 +49,9 @@
    their attributes. Each line of the database may have one of the following
    formats.
   </para>
-    <screen>
-nodename                attr[=value],attr[=value],...
+    <screen>nodename                attr[=value],attr[=value],...
 nodename1,nodename2,... attr[=value],attr[=value],...
-nodenames[A-B]          attr[=value],attr[=value],...
-    </screen>
+nodenames[A-B]          attr[=value],attr[=value],...</screen>
   <para>
    Node names are listed without their domain, and are followed by any number of
    spaces or tabs, then the comma-separated list of attributes. Every

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -261,9 +261,9 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
   <sect2>
    <title>Setting up &munge; authentication</title>
    <para>
-    &munge; uses UID/GID values to uniquely identify and authenticate users. Thus,
-    you must take care that users who will authenticate across a network have
-    unified UIDs and GIDs.
+    &munge; uses UID/GID values to uniquely identify and authenticate users.
+    Thus, you must take care that users who will authenticate across a network
+    have matching UIDs and GIDs across all nodes.
    </para>
    <para>
     &munge; credentials have a limited time-to-live, so you must ensure that the

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -147,12 +147,11 @@ nodenames[A-B]          attr[=value],attr[=value],...
   </para>
   <para>
    The <literal>mrsh</literal> back-end requires the
-   <literal>mrshd</literal> to be running on the client. The
+   <literal>mrshd</literal> daemon to be running on the client. The
    <literal>mrsh</literal> back-end does not require the use of reserved
-   sockets. Therefore, it does not suffer from port exhaustion when
-   executing commands on many machines in parallel. For information about
-   setting up the system to use this back-end, see
-   <xref linkend="sec-remote-mrsh"/>
+   sockets, so it does not suffer from port exhaustion when executing commands
+   on many machines in parallel. For information about setting up the system to
+   use this back-end, see <xref linkend="sec-remote-mrsh"/>
   </para>
   <para>
    Remote machines can be specified on the command line, or
@@ -169,7 +168,7 @@ nodenames[A-B]          attr[=value],attr[=value],...
    the <literal>-M</literal> option.
   </para>
   <para>
-   The <filename>machines</filename> file lists all target hosts one per
+   The <filename>machines</filename> file lists all target hosts, one per
    line. The appropriate netgroup can be selected with the
    <literal>-g</literal> command line option.
   </para>


### PR DESCRIPTION
(With my apologies for the misleading branch name; there was more left to do than I realised.)

This is a top-to-bottom copy-edit and update of the whole Guide, with changes from the 15 SP2 release notes brought across manually. I have added prompts  to all applicable [screen] statements, changed some [literal] tags to more appropriate ones such as [packagename] or [command] or [filename]. I have removed angle-brackets around replaceable text in sample commands and replaced them with [replaceable] tags. 

The one exception is the Slurm chapter, which has diverged too far and which I will re-import.