### PR TITLE
Remove duplicate words

### DIFF
--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -1148,7 +1148,7 @@
     A unique design feature of Trilinos is its focus on packages.
    </para>
    <para>
-    This library needs a compiler toolchain and and MPI flavor to be loaded
+    This library needs a compiler toolchain and MPI flavor to be loaded
     beforehand. To load this module, run:
    </para>
 <screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> trilinos</screen>
@@ -1780,7 +1780,7 @@
     results from all of the tasks into one output file.
    </para>
    <para>
-    For this library a compiler toolchain and and MPI flavor needs to be loaded
+    For this library a compiler toolchain and MPI flavor needs to be loaded
     beforehand. To load this module, run:
    </para>
 <screen>&prompt;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> mpip</screen>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -74,7 +74,7 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
    as an alternative to explicit lists of node names.
   </para>
   </sect2>
-  
+
   <sect2 xml:id="sec-nodeattr">
    <title>Nodeattr usage</title>
    <para>
@@ -89,7 +89,7 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
   </para>
   <para>
    The <literal>-c</literal> options will give a comma-separated list, and the
-   <literal>-s</literal> option a space-separated list, of nodes with 
+   <literal>-s</literal> option a space-separated list, of nodes with
    <literal>attr[=val]</literal>.
   </para>
   <para>
@@ -107,7 +107,7 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
 <screen>&prompt;nodeattr -l [node]</screen>
   <para>
    all attributes for a particular node are printed out. If no node
-   paramteter is is given, all attributes of the local node are printed out.
+   paramteter is given, all attributes of the local node are printed out.
   </para>
   <para>
    To perform a syntax check of the genders database, run:
@@ -118,7 +118,7 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
    <literal>-f</literal>.
   </para>
  </sect2>
-  
+
  </sect1>
  <sect1 xml:id="sec-remote-pdsh">
   <title>pdsh &mdash; parallel remote shell program</title>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -1338,7 +1338,7 @@ SlurmdTimeout=3600</screen>
     A new major version of <package>libslurm</package> is provided with each
     service pack of &product;. The old version will not be uninstalled on
     upgrade, and user-provided applications built with an old version should
-    continue to work if the old library used is not older than the the past two
+    continue to work if the old library used is not older than the past two
     versions. It is strongly recommended to rebuild local applications using
     <literal>libslurm</literal> &mdash; such as MPI libraries with Slurm
     support &mdash; as early as possible. This may require updating the user


### PR DESCRIPTION
Made this small commit for onboarding purposes. Duplicate words found by daps stylecheck. 

It looks like my text editor also stripped out some trailing whitespace in remote_administration.xml.