### PR TITLE
Replace outdated slurm chapter

### DIFF
--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -818,7 +818,7 @@ systemctl enable slurmd.service</screen>
    </para>
   </section>
  </section>
- <section xml:id="sec-pam_slurm_adopt">
+ <section xml:id="sec-pam-slurm-adopt">
   <title>Enabling the <literal>pam_slurm_adopt</literal> Module</title>
   <para>
    The <literal>pam_slurm_adopt</literal> module allows restricting access to

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
  type="text/xml"
  title="Profiling step"?>
@@ -6,952 +7,404 @@
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
-<chapter xmlns="http://docbook.org/ns/docbook"
+
+<chapter xml:id="cha-slurm" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
- xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="slurm.xml"
- xml:id="cha-slurm" xml:lang="en" version="5.1">
+ xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Slurm</title>
  <info>
   <abstract>
    <para>
-    <emphasis>Slurm</emphasis> is a workload manager for managing compute jobs
-    on high-performance computing clusters. It can start multiple jobs on a
-    single node or a single job on multiple nodes. Additional components can be
-    used for advanced scheduling and accounting.
-   </para>
-
-   <para>
-    The mandatory components of Slurm are the control daemon
-    <emphasis>slurmctld</emphasis>, which takes care of job scheduling, and the
-    slurm daemon <emphasis>slurmd</emphasis>, responsible for launching compute
-    jobs. Subsequently, nodes running <command>slurmctld</command> are called
-    <emphasis>master nodes</emphasis> and nodes running
-    <command>slurmd</command> are called <emphasis>compute nodes</emphasis>.
-   </para>
-
-   <para>
-    Additional components are a secondary <emphasis>slurmctld</emphasis> acting
-    as standby server for a failover, and the slurm database daemon
-    <emphasis>slurmdbd</emphasis>, which stores the job history and user
-    hierarchy.
+    Slurm is an open-source, fault-tolerant, and highly scalable cluster
+    management and job scheduling system for Linux clusters containing up to
+    65,536 nodes. Components include machine status, partition management,
+    job management, scheduling and accounting modules.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:bugtracker/>
+   <dm:bugtracker></dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
- <sect1 xml:id="sec-scheduler-slurm">
-  <title>Slurm — utility for HPC workload management</title>
-
+ <section xml:id="sec-slurm-install">
+  <title>Installing Slurm</title>
   <para>
-   For a minimal setup of Slurm with a control node and multiple compute nodes,
-   follow these instructions:
+   For a minimal setup to run Slurm with MUNGE support on
+   one control node and multiple compute nodes, follow these instructions:
   </para>
-
-  <sect2 xml:id="sec-slurm-minimal">
-   <title>Minimal installation</title>
+  <procedure>
+   <step>
+    <para>
+     Before installing Slurm, create a user and a group called
+     <literal>slurm</literal>.
+    </para>
+    <important>
+     <title>Make Sure of Consistent UIDs and GIDs for Slurm's Accounts</title>
+     <para>
+      For security reasons, Slurm does not run as the user
+      <systemitem class="username">root</systemitem> but under its own
+      user. It is important that the user
+      <systemitem class="username">slurm</systemitem> has the
+      same UID/GID across all nodes of the cluster.
+     </para>
+     <para>
+      If this user/group does not exist, the package
+      <package>slurm</package> creates this user and group when it is
+      installed. However, this does not guarantee
+      that the generated UIDs/GIDs will be identical on all systems.
+     </para>
+     <para>
+      Therefore, we strongly advise you to create the user/group
+      <systemitem class="username">slurm</systemitem> before
+      installing <package>slurm</package>.
+      If you are using a network directory service such as LDAP for user and
+      group management, you can use it to
+      provide the <systemitem class="username">slurm</systemitem>
+      user/group as well.
+     </para>
+    </important>
+   </step>
+   <step>
+    <para>
+     Install <package>slurm-munge</package> on the control and compute
+     nodes: <command>zypper in slurm-munge</command>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Configure, enable and start <command>munge</command> on the control and
+     compute nodes as described in <xref linkend="sec-remote-mrsh"/>.
+    </para>
+   </step>
+   <step>
+    <para>
+     On the control node, edit <filename>/etc/slurm/slurm.conf</filename>:
+    </para>
+    <substeps>
+     <step>
+      <para>
+       Configure the parameter
+       <literal>ControlMachine=<replaceable>CONTROL_MACHINE</replaceable></literal>
+       with the host name of the control node.
+      </para>
+      <para>
+       To find out the correct host name, run
+       <command>hostname -s</command> on the control node.
+      </para>
+     </step>
+     <step>
+      <para>
+       Additionally add:
+      </para>
+<screen>NodeName=<replaceable>NODE_LIST</replaceable> Sockets=<replaceable>SOCKETS</replaceable> \
+ CoresPerSocket=<replaceable>CORES_PER_SOCKET</replaceable> \
+ ThreadsPerCore=<replaceable>THREADS_PER_CORE</replaceable> \
+ State=UNKNOWN</screen>
+      <para>
+       and
+      </para>
+<screen>PartitionName=normal Nodes=<replaceable>NODE_LIST</replaceable> \
+ Default=YES MaxTime=24:00:00 State=UP</screen>
+      <para>
+       Replace the following parameter values:
+      </para>
+      <itemizedlist>
+       <listitem>
+        <para>
+         <replaceable>NODE_LIST</replaceable> denotes the list of compute
+         nodes. That is, it should contain the output of <command>hostname
+         -s</command> run on each compute node, either comma-separated or as
+         ranges (for example, <literal>foo[1-100]</literal>).
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         <replaceable>SOCKETS</replaceable> denotes the number of sockets.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         <replaceable>CORES_PER_SOCKET</replaceable> denotes the number of
+         cores per socket.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         <replaceable>THREADS_PER_CORE</replaceable> denotes the number of
+         threads for CPUs which can execute more than one thread at a time.
+        </para>
+       </listitem>
+      </itemizedlist>
+      <para>
+       Make sure that <replaceable>SOCKETS</replaceable> *
+       <replaceable>CORES_PER_SOCKET</replaceable> *
+       <replaceable>THREADS_PER_CORE</replaceable> does not exceed the
+       number of system cores on the compute node.
+      </para>
+     </step>
+     <step>
+      <para>
+       On the control node, copy <filename>/etc/slurm/slurm.conf</filename>
+       to all compute nodes:
+      </para>
+<screen>scp /etc/slurm/slurm.conf <replaceable>COMPUTE_NODE</replaceable>:/etc/slurm/</screen>
+     </step>
+     <step>
+      <para>
+       On the control node, start <systemitem class="daemon">slurmctld</systemitem>:
+      </para>
+<screen>systemctl start slurmctld.service</screen>
+      <para>
+       Also enable it so that it starts on every boot:
+      </para>
+<screen>systemctl enable slurmctld.service</screen>
+     </step>
+     <step>
+      <para>
+       On the compute nodes, start and enable
+       <systemitem class="daemon">slurmd</systemitem>:
+      </para>
+<screen>systemctl start slurmd.service
+systemctl enable slurmd.service</screen>
+      <para>
+       The last line causes <systemitem class="daemon">slurmd</systemitem>
+       to be started on every boot automatically.
+      </para>
+     </step>
+    </substeps>
+   </step>
+  </procedure>
+  <section xml:id="sec-slurm-add-cluster">
+   <title>Adding a Cluster to the Database</title>
+   <para>
+    When using <literal>slurmdbd</literal> make sure a table for a cluster is
+    added to the database before <literal>slurmctld</literal> is started (or
+    restart it afterwards). Otherwise, no accounting information may be written
+    to the database.
+   </para>
+   <para>
+    To add a cluster table, run:
+    <command>sacctmgr -i add cluster <replaceable>CLUSTERNAME</replaceable></command>.
+   </para>
+  </section>
+ </section>
+ <section xml:id="sec-slurm-upgrade">
+  <title>Upgrading Slurm</title>
+  <section xml:id="sec-slurm-compatibility">
+   <title>Slurm Upgrade Compatibility</title>
+   <para>
+    New major versions of Slurm are released in regular intervals. With some
+    restrictions (see below), interoperability is guaranteed between 3 consecutive
+    versions. However, unlike updates to maintenance releases (that is, releases
+    which differ in the last version number), upgrades to newer major versions
+    may require more careful planning.
+   </para>
+   <para>
+    For existing products under general support, version upgrades of Slurm are
+    provided regularly. Unlike maintenance updates, these upgrades will not be
+    installed automatically using <literal>zypper patch</literal> but require the
+    administrator to request their installation explicitly. This ensures
+    that these upgrades are not installed unintentionally and gives the
+    administrator the opportunity to plan version upgrades beforehand.
+   </para>
+   <para>
+    On new installations, we recommend installing the latest available
+    version.
+   </para>
+   <para>
+    Slurm uses a segmented version number: The first two segments denote the
+    major version, the final segment denotes the patch level.
+   </para>
+   <para>
+    Check the list below for available major versions.
+   </para>
+   <para>
+    Upgrade packages (that is, packages that were not a part of the
+    module or service pack initially) have their major version encoded in the
+    package name (with periods <literal>.</literal> replaced by underscores
+    <literal>_</literal>). For example, for version 18.08, this would be:
+    <literal>slurm_18_08-*.rpm</literal>.
+   </para>
+   <para>
+    To upgrade the package <package>slurm</package> to 18.08, run the command:
+   </para>
+   <screen>zypper install --force-resolution slurm_18_08</screen>
+   <para>
+    To upgrade Slurm subpackages, proceed analogously.
+   </para>
    <important>
-    <title>Make sure of consistent UIDs and GIDs for &slurm;'s accounts</title>
     <para>
-     For security reasons, Slurm does not run as the user
-     <systemitem
-      class="username">root</systemitem> but under its own
-     user. It is important that the user
-     <systemitem class="username">slurm</systemitem> has the same UID/GID
-     across all nodes of the cluster.
+     If any additional Slurm packages are installed, make sure to upgrade those as well.
+     These include:
     </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       slurm-pam_slurm
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-sview
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       perl-slurm
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-lua
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-torque
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-config-man
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-doc
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-webdoc
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-auth-none
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       pdsh-slurm
+      </para>
+     </listitem>
+    </itemizedlist>
     <para>
-     If this user/group does not exist, the package <package>slurm</package>
-     creates this user and group when it is installed. However, this does not
-     guarantee that the generated UIDs/GIDs will be identical on all systems.
-    </para>
-    <para>
-     Therefore, we strongly advise you to create the user/group
-     <systemitem class="username">slurm</systemitem> before installing
-     <package>slurm</package>. If you are using a network directory service
-     such as LDAP for user and group management, you can use it to provide the
-     <systemitem class="username">slurm</systemitem> user/group as well.
-    </para>
-    <para>
-     It is strongly recommended that all compute nodes share common user
-     home directories. These should be provided through network storage.
+     All Slurm packages should be upgraded at the same time to avoid
+     conflicts between packages of different versions. This can be done by
+     adding them to the <literal>zypper install</literal> command line
+     described above.
     </para>
    </important>
-   <procedure>
-    <step>
-     <para>
-      On the control node, install the <package>slurm</package> with the
-      command <command>zypper in slurm</command>.
-     </para>
-    </step>
-    <step>
-     <para>
-      On the compute nodes, install the <package>slurm-node</package> package
-      with the command <command>zypper in slurm-node</command>.
-     </para>
-    </step>
-    <step>
-     <para>
-      On both control and compute nodes, the package
-      <package>munge</package> will be installed automatically.
-     </para>
-     <para>
-      Configure, enable and start &munge; on the control and compute nodes as
-      described in <xref linkend="sec-remote-munge"/>. Make sure that the same
-      <literal>munge</literal> key is shared across all nodes.
-     </para>
-    </step>
-   </procedure>
-   <procedure>
-    <title>Creating <filename>slurm.conf</filename></title>
-    <step>
-     <para>
-      Edit the main configuration file
-      <filename>/etc/slurm/slurm.conf</filename>:
-     </para>
-     <substeps>
-      <step>
-       <para>
-        Configure the parameter
-        <literal>ControlMachine=<replaceable>CONTROL_MACHINE</replaceable></literal>
-        with the host name of the control node.
-       </para>
-       <para>
-        To find out the correct host name, run <command>hostname -s</command>
-        on the control node.
-       </para>
-      </step>
-      <step>
-       <para>
-        In order to define the compute nodes, add:
-       </para>
-<screen>NodeName=<replaceable>NODE_LIST</replaceable> State=UNKNOWN</screen>
-       <para>
-        This line allows specifying additional per-node parameters, such as
-        <literal>Boards</literal>, <literal>SocketsPerBoard</literal>
-        <literal>CoresPerSocket</literal>, <literal>ThreadsPerCore</literal>,
-        or <literal>CPU</literal>. The actual values of these can be
-        obtained by running the following command on the compute node:
-       </para>
-<screen>slurmd -C</screen>
-       <para>
-        Additionally, the line
-       </para>
-<screen>PartitionName=normal Nodes=<replaceable>NODE_LIST</replaceable> \
-  Default=YES MaxTime=24:00:00 State=UP</screen>
-       <para>
-        has to be added, where <replaceable>NODE_LIST</replaceable> is the list
-        of compute nodes (that is, the output of <command>hostname -s</command>
-        run on each compute node (either comma-separated or as ranges:
-        <literal>node[1-100]</literal>).
-       </para>
-      </step>
-      <step>
-       <para>
-        Now copy the modified configuration file
-        <filename>/etc/slurm/slurm.conf</filename> to the control node and all
-        compute nodes:
-       </para>
-<screen>scp /etc/slurm/slurm.conf <replaceable>COMPUTE_NODE</replaceable>:/etc/slurm/</screen>
-      </step>
-     </substeps>
-    </step>
-    <step>
-     <para>
-      On the control node, start
-      <systemitem class="daemon"
-       >slurmctld</systemitem>:
-     </para>
-<screen>systemctl start slurmctld.service</screen>
-     <para>
-      Also enable it so that it starts on every boot:
-     </para>
-<screen>systemctl enable slurmctld.service</screen>
-    </step>
-    <step>
-     <para>
-      On the compute nodes, start and enable
-      <systemitem class="daemon"
-       >slurmd</systemitem>:
-     </para>
-<screen>systemctl start slurmd.service
- systemctl enable slurmd.service</screen>
-     <para>
-      The last line causes <systemitem class="daemon">slurmd</systemitem> to be
-      started on every boot automatically.
-     </para>
-    </step>
-   </procedure>
-   <procedure>
-    <title>Testing the installation</title>
-    <step>
-     <para>
-      Check the status and availability of the compute nodes with the
-      <command>sinfo</command> command. It should give you the following output
-      in this example:
-     </para>
-<screen>
-PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
-normal*      up 1-00:00:00      2   idle sle15sp2-node[1-2]
-</screen>
-     <para>
-      If the node state is not <literal>idle</literal> see
-      <xref
-       linkend="sec-slurm-faq"/>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Now the Slurm installation can be tested by running:
-     </para>
-<screen>srun sleep 30</screen>
-     <para>
-      This will try to immediately run the <command>sleep</command> on a free
-      compute node. In another shell you can now
-      <footnote>
-       <para>
-        at least within 30 seconds
-       </para>
-      </footnote>
-      run the command:
-     </para>
-<screen>squeue</screen>
-     <para>
-      It will show you the running compute job in an output like this:
-     </para>
-<screen>
-    JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
-        1    normal    sleep     root  R       0:05      1 node02
-</screen>
-    </step>
-    <step>
-     <para>
-      Now you can create the simple shell script
-     </para>
-<screen>
-#!/bin/bash
-echo "started at $(date)"
-sleep 30
-echo "finished at $(date)"
-</screen>
-     <para>
-      save it as <filename>sleeper.sh</filename> and run the shell script in
-      the queue with
-     </para>
-<screen>
-sbatch sleeper.sh
-      </screen>
-     <para>
-      The shell script is executed as soon as enough resources are available.
-      After the execution the output of the shell script is stored in the
-      output file <filename>slurm-${JOBNR}.out</filename>.
-     </para>
-    </step>
-   </procedure>
-  </sect2>
-
-  <sect2 xml:id="sec-slurm-slurmdbd">
-   <title>Install Slurm database</title>
    <para>
-    With the minimal installation, Slurm will only store pending and running
-    jobs. In order to store to finished and failed job data, the storage plugin
-    has to be installed and enabled. Additionally, so-called
-    <emphasis>completely fair scheduling</emphasis> can be enabled, which
-    replaces FIFO
-    <footnote>
+    In addition to the <quote>three-major version rule</quote> mentioned at the
+    beginning of this section, obey the following rules regarding the order of
+    updates:
+   </para>
+   <orderedlist>
+    <listitem>
      <para>
-      <emphasis>f</emphasis>irst <emphasis>i</emphasis>n
-      <emphasis>f</emphasis>irst <emphasis>o</emphasis>ut.
+      The version of <literal>slurmdbd</literal> must be identical to or higher
+      than the version of <literal>slurmctld</literal>
      </para>
-    </footnote>
-    scheduling with algorithms which calculate the job priority in a queue in
-    dependence of the job which a user has run in the history.
+    </listitem>
+    <listitem>
+     <para>
+      The version of <literal>slurmctld</literal> must the identical to or higher
+      than the version of <literal>slurmd</literal>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The version of <literal>slurmd</literal> must be identical to or higher
+      than the version of the <literal>slurm</literal> user applications.
+     </para>
+    </listitem>
+   </orderedlist>
+   <para>
+    Or in short:
    </para>
    <para>
-    The Slurm database has two components: the <literal>slurmdbd</literal>
-    daemon itself, and a SQL database, where &mariadb; is recommended. The
-    database can be on the same node which runs <literal>slurmdbd</literal> or
-    another node. For this simple setup, all these services run on the same
-    node.
-   </para>
-   <procedure>
-    <title>Install <package>slurmdbd</package></title>
-    <note>
-     <title>&mariadb;</title>
-     <para>
-      If you want to use an external SQL database (or such a database is
-      already installed on the control node), you can skip the
-      &mariadb;-related steps.
-     </para>
-    </note>
-    <step>
-     <para>
-      Install the &mariadb; SQL database with <command>zypper in
-      mariadb</command>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Start and enable &mariadb; with the following commands:
-     </para>
-<screen>systemctl start mariadb
-systemctl enable mariadb</screen>
-    </step>
-    <step>
-     <para>
-      Now the database should be secure with the command
-      <command>mysql_secure_installation</command>.
-     </para>
-    </step>
-    <step xml:id="sec-sum-sqldb">
-     <para>
-      In this step, the database and the user for the Slurm database have to be
-      created. This is done by connecting to the SQL database, for example with
-      the command <command>mysql -u root -p</command>. After a successful
-      connection to the database and the creation of a secure password
-      <footnote>
-       <para>
-        You can use the command <command>openssl rand -base64 32</command> to
-        create a secure random password
-       </para>
-      </footnote>
-      , the Slurm user and the database are created with the commands:
-     </para>
-<screen>
-create user 'slurm'@'localhost' identified by 'password';
-grant all on slurm_acct_db.* TO 'slurm'@'localhost';
-create database slurm_acct_db;</screen>
-    </step>
-    <step>
-     <para>
-      The package <package>slurmdbd</package> can be installed with the command
-     </para>
-<screen>zypper in slurm-slurmdbd</screen>
-     <para>
-      Now the configuration file <filename>/etc/slurm/slurmdbd.conf</filename>
-      for <literal>slurmdbd</literal> has to be modified so that the daemon can
-      access the database. Change the following lines
-     </para>
-<screen>StoragePass=password</screen>
-     <para>
-      to the password which you used in <xref linkend="sec-sum-sqldb"/>. If you
-      chose another location or user for the SQL database, you also need to
-      modify the following entries:
-     </para>
-<screen>StorageUser=slurm
-DbdAddr=localhost
-DbdHost=localhost</screen>
-    </step>
-    <step>
-     <para>
-      The daemon <literal>slurmdbd</literal> should now be started and enabled
-      with the commands
-     </para>
-<screen>systemctl start slurmdbd
-systemctl enable slurmdbd</screen>
-     <para>
-      The first start of <literal>slurmdbd</literal> will take some time.
-     </para>
-    </step>
-    <step>
-     <para>
-      To enable accounting, you have to have change/add the following lines for
-      the connection between the <literal>slurmctld</literal> and the
-      <literal>slurmdbd</literal> daemon:
-     </para>
-<screen>JobAcctGatherType=jobacct_gather/linux
-JobAcctGatherFrequency=30
-AccountingStorageType=accounting_storage/slurmdbd
-AccountingStorageHost=localhost</screen>
-     <para>
-      In the example above, we assume that <literal>slurmdbd</literal> is
-      running on the same host as <literal>slurmctld</literal>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Restart the <literal>slurmctld</literal> with:
-     </para>
-<screen>systemctl restart slurmctld</screen>
-    </step>
-    <step performance="optional">
-     <para>
-      By default, Slurm does not take any group membership into account, and it
-      is not possible to map the system groups to Slurm. Group creation and
-      membership have to be managed via the command line tool
-      <command>sacctmgr</command>. It is also possible to have a group
-      hierarchy, and users can be part of several groups.
-     </para>
-     <note>
-      <para>
-       When using slurmdbd make sure a table for a cluster is added to the
-       database before slurmctld is started (or restart it afterwards).
-       Otherwise, no accounting information may be written to the database.
-       To add a cluster table, run:
-       <command>sacctmgr -i add cluster <replaceable>CLUSTERNAME</replaceable></command>.
-      </para>
-     </note>
-     <para>
-      To create an umbrella group <literal>bavaria</literal> for two subgroups
-      called <literal>nuremberg</literal> and <literal>munich</literal>, use
-      the following commands:
-     </para>
-<screen>sacctmgr add account bavaria \
-  Description="umbrella group for subgroups" Organization=bavaria
-sacctmgr add account nuremberg,munich parent=bavaria
-Description="subgroup" Organization=bavaria</screen>
-     <para>
-      With the similar syntax you can add now users to the accounts:
-     </para>
-<screen>sacctmgr add user tux Account=nuremberg</screen>
-    </step>
-   </procedure>
-  </sect2>
- </sect1>
- <sect1 xml:id="sec-slurm-adm-commands">
-  <title>Slurm administration commands</title>
-
-  <sect2 xml:id="sec-slurm-sconfigure">
-   <title>scontrol</title>
-   <para>
-    The command <command>scontrol</command> is used to show and update the
-    entities of Slurm, such as the state of the compute nodes or compute jobs.
-    It can also be used to reboot or to propagate configuration changes to the
-    compute nodes.
+    version(<literal>slurmdbd</literal>) &gt;=
+    version(<literal>slurmctld</literal>) &gt;=
+    version(<literal>slurmd</literal>) &gt;= version (Slurm user CLIs).
    </para>
    <para>
-    Useful options to this command are <literal>--details</literal>, which will
-    print more verbose output, and <literal>--oneliner</literal>, which forces
-    the output onto a single line, which is more useful in shell scripts.
+    With each version, configuration options for
+    <literal>slurmctld</literal>/<literal>slurmd</literal> or
+    <literal>slurmdbd</literal> may
+    be deprecated. While deprecated, they will remain valid for this version and
+    the two subsequent versions but they may be removed later.
    </para>
-   <variablelist>
-    <varlistentry>
-     <term><command>scontrol show <replaceable>ENTITY</replaceable></command></term>
-     <listitem>
-      <para>
-       will display the state of the specified
-       <replaceable>ENTITY</replaceable>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><command>scontrol update <replaceable>SPECIFICATION</replaceable></command></term>
-     <listitem>
-      <para>
-       can be used to update the <replaceable>SPECIFICATION</replaceable> like
-       the compute node or compute node state.
-      </para>
-      <para>
-       Useful <replaceable>SPECIFICATION</replaceable> states for compute nodes
-       which can be set are:
-      </para>
-      <variablelist>
-       <varlistentry>
-        <term>nodename=<replaceable>NODE</replaceable> state=drain reason=<replaceable>REASON</replaceable></term>
-        <listitem>
-         <para>
-          will drain the compute node so that no <emphasis>new</emphasis> jobs
-          can be scheduled on the compute node, but will node end compute jobs
-          running on the compute node. <replaceable>REASON</replaceable> could
-          be any string.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>nodename=<replaceable>NODE</replaceable> state=down reason=<replaceable>REASON</replaceable></term>
-        <listitem>
-         <para>
-          is removing all jobs from the compute node
-          <replaceable>NODE</replaceable>, any jobs on the node will be
-          aborted.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>nodename=<replaceable>NODE</replaceable> state=drain reason=<replaceable>REASON</replaceable></term>
-        <listitem>
-         <para>
-          will drain the compute node so that no <emphasis>new</emphasis> jobs
-          can be scheduled on the compute node, but will node end compute jobs
-          running on the compute node. <replaceable>REASON</replaceable> could
-          be any string.
-         </para>
-         <para>
-          The compute node will stay in <literal>drained</literal> state and
-          must be put back to the idle state with the next listed command.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>nodename=<replaceable>NODE</replaceable> state=resume</term>
-        <listitem>
-         <para>
-          marks the compute node <replaceable>NODE</replaceable> to be ready
-          for a return to the <literal>idle</literal> state.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>jobid=<replaceable>JOBID</replaceable><replaceable>REQUIREMENT</replaceable>=<replaceable>VALUE</replaceable></term>
-        <listitem>
-         <para>
-          will update the given requirement, such as
-          <literal>NumNodes</literal>, with a new value. This command can also
-          be executed as a normal user.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>reconfigure</term>
-     <listitem>
-      <para>
-       will trigger a reload of the configuration file
-       <filename>slurm.conf</filename> on all compute nodes.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>reboot <replaceable>NODELIST</replaceable></term>
-     <listitem>
-      <para>
-       can be used to reboot a compute node, as soon as the jobs on it have
-       finished. The option <literal>RebootProgram="/sbin/reboot"</literal>
-       have to be set in <filename>slurm.conf</filename> to use this command.
-      </para>
-      <para>
-       When the reboot of a compute node takes more than 60 seconds, you can
-       set a higher value for the parameter, such as
-       <literal>ResumeTimeout=300</literal> in <filename>slurm.conf</filename>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><command>sacctmgr</command></term>
-     <listitem>
-      <para>
-       is used for job accounting within Slurm. The service
-       <literal>slurmdbd</literal> has to be setup in order to use this
-       command. Follow the steps in <xref linkend="sec-sum-sqldb"/> to setup
-       <literal>slurmdbd</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><command>sinfo</command></term>
-     <listitem>
-      <para>
-       retrieves information about the state of the compute nodes, and can be
-       used for a fast overview of the cluster health. The following
-       command-line switches are available:
-      </para>
-      <variablelist>
-       <varlistentry>
-        <term><command>--dead</command></term>
-        <listitem>
-         <para>
-          displays information about unresponsive nodes.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--long</command></term>
-        <listitem>
-         <para>
-          shows more detailed information.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--reservation</command></term>
-        <listitem>
-         <para>
-          prints information about advanced reservations.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>-R</command></term>
-        <listitem>
-         <para>
-          displays the reason why a node is in the <literal>down</literal>,
-          <literal>drained</literal>, or <literal>failing</literal> state.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--state=<replaceable>STATE</replaceable></command></term>
-        <listitem>
-         <para>
-          limit the output only to nodes with the specified
-          <replaceable>STATE</replaceable> state.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><command>sacct</command></term>
-     <listitem>
-      <para>
-       when accounting is enabled, displays the accounting data. The following
-       options are available:
-      </para>
-      <variablelist>
-       <varlistentry>
-        <term><command>--allusers</command></term>
-        <listitem>
-         <para>
-          show accounting data for all users.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--accounts</command>=<replaceable>NAME</replaceable></term>
-        <listitem>
-         <para>
-          only the specified user(s) are shown
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--starttime</command>=<replaceable>MM/DD[/YY]-HH:MM[:SS]</replaceable></term>
-        <listitem>
-         <para>
-          only jobs after starttime will be shown. You can use just
-          <replaceable>MM/DD</replaceable> or <replaceable>HH:MM</replaceable>.
-          If no time is given, defaults to <literal>00:00</literal>, which
-          means that only jobs from today are shown.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--endtime</command>=<replaceable>MM/DD[/YY]-HH:MM[:SS]</replaceable></term>
-        <listitem>
-         <para>
-          accepts the same options as for <command>--starttime</command>. If
-          not set, the time when the command was issued is used.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--name</command>=<replaceable>NAME</replaceable></term>
-        <listitem>
-         <para>
-          limit output to jobs with the given <replaceable>NAME</replaceable>
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--partition</command>=<replaceable>PARTITION</replaceable></term>
-        <listitem>
-         <para>
-          show only jobs which run in <replaceable>PARTITION</replaceable>.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><command>sbatch</command>, <command>salloc</command> and <command>srun</command></term>
-     <listitem>
-      <para>
-       these commands are used to schedule <emphasis>compute jobs</emphasis>,
-       which means batch scripts for the <command>sbatch</command> command,
-       interactive sessions for the <command>salloc</command> command, or
-       binaries for the <command>srun</command> command.
-      </para>
-      <para>
-       Note that if the job cannot be scheduled immediately, only
-       <command>sbatch</command> will place it into the queue.
-      </para>
-      <para>
-       Frequently-used options for these commands are:
-      </para>
-      <variablelist>
-       <varlistentry>
-        <term><command>-n <replaceable>COUNT_THREADS</replaceable></command></term>
-        <listitem>
-         <para>
-          specifies the number of threads needed by the job. The threads can be
-          allocated on different nodes.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>-N <replaceable>MINCOUNT_NODES[-MAXCOUNT_NODES]</replaceable></command></term>
-        <listitem>
-         <para>
-          sets the number of compute nodes which are required for a job. The
-          <replaceable>MAXCOUNT_NODES</replaceable> number can be omitted.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--time <replaceable>TIME</replaceable></command></term>
-        <listitem>
-         <para>
-          specifies the maximal clocktime (runtime) after which a job is
-          killed. The format of <replaceable>TIME</replaceable> is either
-          seconds or <replaceable>[HH:]MM:SS</replaceable>. Not to be confused
-          with <command>walltime</command>, which is <literal>clocktime &times;
-          threads</literal>.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--signal <replaceable>[B:]NUMBER[@TIME]</replaceable></command></term>
-        <listitem>
-         <para>
-          means that the signal specified by <replaceable>NUMBER</replaceable>
-          will be sent 60 seconds before the end of the job, unless
-          <replaceable>TIME</replaceable> was specified. The signal will be
-          sent to every process on every node. If a signal should only be sent
-          to the controlling batch job, you must specify the
-          <command>B:</command> flag.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--job-name <replaceable>NAME</replaceable></command></term>
-        <listitem>
-         <para>
-          set the name of the job to <replaceable>NAME</replaceable> in the
-          queue.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--array=<replaceable>RANGEINDEX</replaceable></command></term>
-        <listitem>
-         <para>
-          execute the given script via <command>sbatch</command> for indexes
-          given by <replaceable>RANGEINDEX</replaceable> with the same
-          parameters.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--dependency=<replaceable>STATE:JOBID</replaceable></command></term>
-        <listitem>
-         <para>
-          defer job until specified <replaceable>STATE</replaceable> of job
-          <replaceable>JOBID</replaceable> has been reached.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--gres=<replaceable>GRES</replaceable></command></term>
-        <listitem>
-         <para>
-          run a job only on nodes with the specified <emphasis>generic
-          resource</emphasis> (GRes), for example a GPU, specified by the value
-          of <replaceable>GRES</replaceable>.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--licenses=<replaceable>NAME[:COUNT]</replaceable></command></term>
-        <listitem>
-         <para>
-          the job must have the number specified in
-          <replaceable>COUNT</replaceable> of licenses with the name
-          <replaceable>NAME</replaceable>. A license is the opposite of a
-          generic resource: it is not tied to a computer, but is a cluster-wide
-          variable.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--mem=<replaceable>MEMORY</replaceable></command></term>
-        <listitem>
-         <para>
-          sets the real memory <replaceable>MEMORY</replaceable> needed by a
-          job per node. To use this option, memory control must be enabled. The
-          default unit for the <replaceable>MEMORY</replaceable> value is
-          megabytes, but you can also use <literal>K</literal> for kilobyte,
-          <literal>M</literal> for megabyte, <literal>G</literal> for gigabyte,
-          and <literal>T</literal> for terabyte.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><command>--mem-per-cpu=<replaceable>MEMORY</replaceable></command></term>
-        <listitem>
-         <para>
-          This takes the same options as <command>--mem</command>, but defines
-          memory on a per-CPU basis rather than a per-node basis.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </sect2>
- </sect1>
- <sect1 xml:id="sec-slurm-upgrade">
-  <title>Upgrading Slurm</title>
-
-  <para>
-   New major versions of Slurm are released in regular intervals. With some
-   restrictions (see below), interoperability is guaranteed between three
-   consecutive versions. However, unlike updates to maintenance releases (that
-   is, releases which differ in the last version number), upgrades to later
-   major versions may require more careful planning.
-  </para>
-
-  <para>
-   For existing products under general support, version upgrades of Slurm are
-   provided regularly. Unlike maintenance updates, these upgrades will not be
-   installed automatically using <literal>zypper patch</literal> but require
-   the administrator to request their installation explicitly. This is to
-   ensure that these upgrades are not installed unintentionally and gives the
-   administrator the opportunity to plan version upgrades beforehand.
-  </para>
-
-  <para>
-   On new installations, we recommend installing the latest available version.
-  </para>
-
-  <para>
-   Slurm uses a segmented version number: The first two segments denote the
-   major version, the final segment denotes the patch level.
-  </para>
-
-  <para>
-   Check the list below for available major versions.
-  </para>
-
-  <para>
-   Upgrade packages (that is, packages that were not initially supplied with
-   the module or service pack) have their major version encoded in the package
-   name (with periods <literal>.</literal> replaced by underscores
-   <literal>_</literal>). For example, for version 18.08, this would be:
-   <literal>slurm_18_08-*.rpm</literal>.
-  </para>
-
-  <para>
-   To upgrade the package <package>slurm</package> to 18.08, run the command:
-  </para>
-
-<screen>zypper install --force-resolution slurm_18_08</screen>
-
-  <para>
-   To upgrade Slurm subpackages, use the analogous commands.
-  </para>
-
-  <para>
-   In addition to the <quote>three major-version rule</quote> mentioned at the
-   beginning of this section, obey the following rules regarding the order of
-   updates:
-  </para>
-
-  <orderedlist>
-   <listitem>
-    <para>
-     The version of <literal>slurmdbd</literal> must be identical to or higher
-     than the version of <literal>slurmctld</literal>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The version of <literal>slurmctld</literal> must the identical to or
-     higher than the version of <literal>slurmd</literal>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The version of <literal>slurmd</literal> must be identical to or higher
-     than the version of the <literal>slurm</literal> user applications.
-    </para>
-   </listitem>
-  </orderedlist>
-
-  <para>
-   Or in short:
-  </para>
-
-  <para>
-   version(<literal>slurmdbd</literal>) &gt;=
-   version(<literal>slurmctld</literal>) &gt;=
-   version(<literal>slurmd</literal>) &gt;= version (Slurm user CLIs).
-  </para>
-
-  <para>
-   With each version, configuration options for
-   <literal>slurmctld</literal>/<literal>slurmd</literal> or
-   <literal>slurmdbd</literal> may be deprecated. While deprecated they will
-   remain valid for this version and the two consecutive ones but they may be
-   removed later.
-  </para>
-
-  <para>
-   Therefore, it is advisable to update the configuration files after the
-   upgrade and replace deprecated configuration options before the final
-   restart of a service.
-  </para>
-
-  <para>
-   It should be noted that a new major version of Slurm introduces a new
-   version of <literal>libslurm</literal>. Older versions of this library might
-   no longer work with an upgraded Slurm. For all &slea; software depending on
-   <literal>libslurm </literal>, an upgrade will be provided. Any
-   locally-developed Slurm modules or tools may require modification and/or
-   recompilation.
-  </para>
-
-  <sect2 xml:id="sec-slurm-upgrade-workflow">
-   <title>Upgrade workflow</title>
    <para>
-    For this workflow, we assume that MUNGE authentication is used and that
-    <literal>pdsh</literal>, the pdsh Slurm plugin and mrsh are usable to
-    access the all machines of the cluster (that is <literal>mrshd</literal> is
-    running on all nodes in the cluster).
+    Therefore, it is advisable to update the configuration files after the
+    upgrade and replace deprecated configuration options before finally
+    restarting a service.
+   </para>
+   <para>
+    It should be noted that a new major version of Slurm introduces a new version
+    of <literal>libslurm</literal>. Older versions of this library might no longer
+    work with an upgraded Slurm. For all &slea; software depending on
+    <literal>libslurm </literal> an upgrade will be provided. Any locally
+    developed Slurm modules or tools might require modification and/or
+    recompilation.
+   </para>
+  </section>
+  <section xml:id="sec-slurm-upgrade-workflow">
+   <title>Upgrade Workflow</title>
+   <para>
+    For this workflow it is assumed that
+    MUNGE authentication is used and that
+    <literal>pdsh</literal>, the <literal>pdsh</literal> Slurm plugin and
+    <literal>mrsh</literal> can be used to access all machines of the cluster.
+    That means, <literal>mrshd</literal> is running on all nodes in the cluster.
    </para>
    <para>
     If this is not the case, install <literal>pdsh</literal>:
    </para>
-<screen>&prompt;zypper in pdsh-slurm</screen>
+ <screen>&prompt;zypper in pdsh-slurm</screen>
    <para>
-    if <literal>mrsh</literal> is not used in the cluster, the
-    <literal>ssh</literal> back-end for <literal>pdsh</literal> may be used as
-    well for this, simply replace the option <literal>-R mrsh</literal> by
-    <literal>-R ssh</literal>in the <literal>pdsh</literal>commands below. This
-    is less scalable and you may run out of usable ports.
+    If <literal>mrsh</literal> is not used in the cluster, the
+    SSH back-end for <literal>pdsh</literal> can be used as
+    well for this: Replace the option <literal>-R mrsh</literal> with
+    <literal>-R ssh</literal> in the <literal>pdsh</literal> commands below.
+    This is less scalable and you may run out of usable ports.
    </para>
-   <procedure xml:id="pro-slurm-upgrade-workflow">
+   <warning>
+    <title>Upgrade <literal>slurmdbd</literal> databases before other Slurm components</title>
+    <para>
+     If <literal>slurmdbd</literal> is used, always upgrade the
+     <literal>slurmdbd</literal> database <emphasis>before</emphasis> starting
+     the upgrade of any other Slurm component.
+     The same database can be connected multiple clusters and must be upgraded
+     before all of them.
+    </para>
+    <para>
+     Upgrading other Slurm components before the database can lead to data loss.
+    </para>
+   </warning>
+   <procedure xml:id="pro-slurm-upgrade-procedure">
     <title>Upgrading Slurm</title>
     <step>
      <para>
-      <emphasis role="bold">Upgrade slurmdbd Database Daemon</emphasis>
+      <emphasis role="bold">Upgrade <literal>slurmdbd</literal> Database Daemon</emphasis>
      </para>
      <para>
-      If the database daemon <literal>slurmdbd</literal> is used, it must be
-      upgraded first. Care must be taken if the same database is used for
-      multiple clusters. The database needs to be updated before any cluster is
-      updated.
+      Upon the first start of <literal>slurmdbd</literal> after a
+      <literal>slurmdbd</literal> upgrade, it will convert its database.
+      If the database is large, the conversion will take several 10s of minutes.
+      During this time, the database is not accessible.
      </para>
      <para>
-      It should be noted that when upgrading <literal>slurmdbd</literal>, a
-      conversion of the database will take place when the new version of
-      <literal>slurmdbd</literal> is started for the first time. If the
-      database is big the conversion will take several tens of minutes. During
-      this time, the database will be inaccessible.
-     </para>
-     <para>
-      It is highly recommended to create a backup of the database in case an
-      error occurs during the upgrade process or afterwards: without a backup
-      all accounting data collected in the database may be lost if an error
-      occurs or the upgrade must be rolled back for some reason. A database
+      We strongly recommend creating a backup of the database in case an
+      error occurs during or after the upgrade process.
+      Without a backup, all accounting data collected in the database might
+      be lost in such an event.
+      A database
       converted to a newer version cannot be converted back to an older one and
       older versions of <literal>slurmdbd</literal> will not recognize the
-      newer formats. To backup and upgrade <literal>slurmdbd</literal> you may
+      newer formats. To back up and upgrade <literal>slurmdbd</literal>,
       follow this procedure:
      </para>
      <substeps>
@@ -959,79 +412,81 @@ Description="subgroup" Organization=bavaria</screen>
        <para>
         Stop the <literal>slurmdbd</literal> service:
        </para>
-<screen>&prompt;rcslurmdbd stop</screen>
+       <screen>&prompt;rcslurmdbd stop</screen>
        <para>
         Make sure that <literal>slurmdbd</literal> is not running anymore:
        </para>
-<screen>&prompt;rcslurmdbd status</screen>
+       <screen>&prompt;rcslurmdbd status</screen>
        <para>
-        It should be noted that <literal>slurmctld</literal> might remain
-        running while the database daemon is down. While it is down, requests
-        intended for <literal>slurmdbd</literal> are queued internally. The DBD
-        Agent Queue size is limited, however, and should therefore be monitored
-        with <literal>sdiag</literal>.
+        It should be noted that <literal>slurmctld</literal> might remain running
+        while the database daemon is down. While it is down, requests intended
+        for <literal>slurmdbd</literal> are queued internally. The DBD Agent
+        Queue size is limited, however, and should therefore be monitored with
+        <literal>sdiag</literal>.
        </para>
       </step>
       <step>
        <para>
-        Create a backup of the slurm_acct_db database:
+        Create a backup of the <literal>slurm_acct_db</literal> database:
        </para>
-<screen>&prompt;mysqldump -p slurm_acct_db &gt; slurm_acct_db.sql</screen>
-       <para>
-        If needed, this can be restored calling:
-       </para>
-<screen>&prompt;mysql -p slurm_acct_db &lt; slurm_acct_db.sql</screen>
+       <screen>&prompt;mysqldump -p slurm_acct_db &gt; slurm_acct_db.sql</screen>
+       <note role="compact">
+        <para>
+         If needed, this can be restored by running:
+        </para>
+        <screen>&prompt;mysql -p slurm_acct_db &lt; slurm_acct_db.sql</screen>
+       </note>
       </step>
       <step>
        <para>
-        In preparation of the conversion, make sure, the variable
+        In preparation of the conversion, make sure the variable
         <literal>innodb_buffer_size</literal> is set to a value &gt;= 128 Mb:
        </para>
        <para>
         On the database server, run:
        </para>
-<screen>&prompt;echo  'SELECT @@innodb_buffer_pool_size/1024/1024;' | \
+ <screen>&prompt;echo  'SELECT @@innodb_buffer_pool_size/1024/1024;' | \
   mysql --password --batch</screen>
        <para>
-        If the size is less than 128&nbsp;MB, it can be changed on the fly for
-        the current session (on <literal>mariadb</literal>)
+        If the size is less than 128 Mb, it can be changed on the fly for the
+        current session (on <literal>mariadb</literal>):
        </para>
-<screen>&prompt;echo 'set GLOBAL innodb_buffer_pool_size = 134217728;' | \
+ <screen>&prompt;echo 'set GLOBAL innodb_buffer_pool_size = 134217728;' | \
   mysql --password --batch</screen>
        <para>
-        or permanently by editing <filename>/etc/my.cnf</filename>, setting it
-        to 128&nbsp;MB then restarting the database:
+        Alternatively, the size can be changed permanently by editing
+        <filename>/etc/my.cnf</filename> and setting it to 128 Mb.
+        Then restart the database:
        </para>
-<screen>&prompt;rcmysql restart</screen>
+       <screen>&prompt;rcmysql restart</screen>
       </step>
-      <step xml:id="step-slurm-upgrade-workflow-install-slurmdbd">
+      <step xml:id="st-slurm-install-slurmdbd">
        <para>
         Install the upgrade of <literal>slurmdbd</literal>:
        </para>
-<screen>zypper install --force-resolution slurm_<replaceable>version</replaceable>-slurmdbd</screen>
+       <screen>zypper install --force-resolution slurm_<replaceable>version</replaceable>-slurmdbd</screen>
        <note>
-        <title>Update &mariadb; separately</title>
+        <title>Update MariaDB Separately</title>
         <para>
          If you also need to update <literal>mariadb</literal>, it is
          recommended to perform this step separately,
-         <emphasis>before</emphasis> performing step
-         <xref
-          linkend="step-slurm-upgrade-workflow-install-slurmdbd"/>.
+         <emphasis>before</emphasis> performing
+         <xref linkend="st-slurm-install-slurmdbd"/>.
         </para>
        </note>
        <substeps>
         <step>
          <para>
-          Upgrade &mariadb;:
+          Upgrade MariaDB:
          </para>
-<screen>&prompt;zypper update mariadb</screen>
+         <screen>&prompt;zypper update mariadb</screen>
         </step>
         <step>
          <para>
           Run the conversion of the database tables to the new version of
-          &mariadb;:
+          MariaDB:
          </para>
-<screen>mysql_upgrade --user=root --password=<replaceable>root_db_password</replaceable>;</screen>
+         <screen>mysql_upgrade --user=root --password=<replaceable>root_db_password</replaceable>;</screen>
         </step>
        </substeps>
       </step>
@@ -1040,69 +495,67 @@ Description="subgroup" Organization=bavaria</screen>
         <emphasis role="bold">Rebuild database</emphasis>
        </para>
        <para>
-        Since a conversion may take a considerable amount of time, the systemd
-        service may run into a timeout during the conversion. Thus we recommend
-        performing the migration manually, by running
+        Because a conversion can take a considerable amount of time, the systemd
+        service can run into a timeout during the conversion. Thus we recommend
+        to perform the migration manually by running
         <literal>slurmdbd</literal> from the command line in the foreground:
        </para>
-<screen>&prompt;/usr/sbin/slurmdbd -D -v</screen>
+ <screen>&prompt;/usr/sbin/slurmdbd -D -v</screen>
        <para>
-        Once you see the message:
+        When you see the below message, <literal>slurmdbd</literal> can be shut
+        down:
        </para>
-<screen>Conversion done:
-success!</screen>
+ <screen>Conversion done:
+ success!</screen>
        <para>
-        <literal>slurmdbd</literal> may be shut down with signal
-        <literal>SIGTERM</literal> (that is, by pressing <keycombo>
-        <keycap function="control"/> <keycap>C</keycap> </keycombo>).
+         To do so, use signal <literal>SIGTERM</literal> (that is, press
+        <keycombo><keycap function="control"/><keycap>C</keycap></keycombo>).
        </para>
        <para>
-        When using a backup <literal>slurmdbd</literal>, the conversion needs
-        to be performed on the primary. The backup will start after the
-        conversion has completed.
+        When using a backup <literal>slurmdbd</literal>, the conversion needs to be performed
+        on the primary. The backup will not start until the conversion has
+        taken place.
        </para>
       </step>
       <step>
        <para>
-        Before restarting the service, you should remove or replace any
-        deprecated configuration options. Check the list of deprecated options
-        below. After this has been completed, restart
-        <command>slurmdbd</command>:
+        Before restarting the service, remove or replace deprecated
+        configuration options.
+        <!--For a list of deprecated options, see
+        <xref linkend="package-slurm-configuration-change"/>.
+        SP3 equivalent: https://www.suse.com/releasenotes/x86_64/SLE-HPC/15-SP3/#_deprecation_of_packages -->
        </para>
-<screen>&prompt;systemctl start slurmdbd</screen>
+       <para>
+        When this has been completed, restart
+        <literal>slurmdbd</literal>.
+        During the database rebuild that <literal>slurmdbd</literal> performs
+        upon the first start, it will not daemonize.
+       </para>
        <note>
-        <title>No daemonization during rebuild</title>
+        <title>Convert Primary <literal>slurmbd</literal> First</title>
         <para>
-         During the rebuild of the Slurm database, the database daemon does not
-         daemonize.
+         If a backup database daemon is used, the primary one needs to be
+         converted first. The backup will not start until this has happened.
         </para>
        </note>
-       <note>
-        <title>Convert primary <systemitem class="daemon">slurmdbd</systemitem> first</title>
-        <para>
-         If a backup <systemitem class="daemon">slurmdbd</systemitem> daemon is used,
-         the primary  <systemitem class="daemon">slurmdbd</systemitem> needs to be
-         upgraded and run to perform the conversion first. The backup
-         <systemitem class="daemon">slurmdbd</systemitem> will not
-         start until this has happened.
-        </para>
-       </note>
+       <para>
+        Only after the conversion has been completed, the backup will start.
+       </para>
       </step>
      </substeps>
     </step>
     <step>
      <para>
-      <emphasis role="bold">Update <literal>slurmctld</literal> and
-      <literal>slurmd</literal></emphasis>
+      <emphasis role="bold">Update slurmctld and slurmd</emphasis>
      </para>
      <para>
-      Once the Slurm database has been updated, the
-      <literal>slurmctld</literal> and <literal>slurmd</literal> instances may
-      be updated. It is recommended to update the head and compute nodes all in
-      a single pass. If this is not feasible, the compute nodes
-      (<literal>slurmd</literal>) may be updated on a node-by-node basis.
-      However, this requires that the master nodes
-      (<literal>slurmctld</literal>) have been updated successfully.
+      When the Slurm database has been updated, the
+      <literal>slurmctld</literal> and <literal>slurmd</literal>
+      instances can be updated. We recommend updating the head and compute
+      nodes all in a single pass. If this is not feasible, the compute nodes
+      (<literal>slurmd</literal>) can be updated on a node-by-node basis.
+      However, this requires that the master nodes (<literal>slurmctld</literal>)
+      have been updated successfully.
      </para>
      <substeps>
       <step>
@@ -1114,9 +567,8 @@ success!</screen>
        <para>
         It is advisable to create a backup copy of the Slurm configuration
         before starting the upgrade process. Since the configuration file
-        <filename>/etc/slurm/slurm.conf</filename> should be identical across
-        the entire cluster, it is sufficient to do so on the master controller
-        node.
+        <literal>/etc/slurm/slurm.conf</literal> should be identical across the
+        entire cluster, it is sufficient to do so on the master controller node.
        </para>
       </step>
       <step xml:id="st-slurm-timeout">
@@ -1126,50 +578,50 @@ success!</screen>
        <para>
         Set <literal>SlurmdTimeout</literal> and
         <literal>SlurmctldTimeout</literal> in
-        <filename>/etc/slurm/slurm.conf</filename> to sufficiently high values
-        to avoid timeouts while <literal>slurmctld</literal> and
+        <literal>/etc/slurm/slurm.conf</literal> to sufficiently high values to
+        avoid timeouts while <literal>slurmctld</literal> and
         <literal>slurmd</literal> are down. We recommend at least 60 minutes,
-        and more on larger clusters.
+        more on larger clusters.
        </para>
        <substeps>
         <step>
          <para>
-          Edit <filename>/etc/slurm/slurm.conf</filename> on the master
-          controller node and set the values for this variable to at least 3600
-          (one hour).
+          Edit <literal>/etc/slurm/slurm.conf</literal> on the master controller
+          node and set the values for this variable to at least
+          <literal>3600</literal> (1 hour).
          </para>
-<screen>SlurmctldTimeout=3600
-SlurmdTimeout=3600</screen>
+ <screen>SlurmctldTimeout=3600
+ SlurmdTimeout=3600</screen>
         </step>
-        <step>
+        <step xml:id="st-slurm-configuration-distribute">
          <para>
-          Copy <filename>/etc/slurm/slurm.conf</filename> to all nodes, if
-          MUNGE authentication is used in the cluster as recommended.
+          Copy <literal>/etc/slurm/slurm.conf</literal> to all nodes. If
+          MUNGE authentication is used in the cluster as
+          recommended, use these steps:
          </para>
          <substeps>
           <step>
            <para>
-            Obtain the list of partitions in
-            <filename>/etc/slurm/slurm.conf</filename>.
+            Obtain the list of partitions in <filename>/etc/slurm/slurm.conf</filename>.
            </para>
           </step>
           <step>
            <para>
             Execute:
            </para>
-<screen>&prompt;cp /etc/slurm/slurm.conf /etc/slurm/slurm.conf.update
-&prompt;sudo -u slurm /bin/bash -c 'cat /etc/slurm/slurm.conf.update \
+ <screen>&prompt;cp /etc/slurm/slurm.conf /etc/slurm/slurm.conf.update
+ &prompt;sudo -u slurm /bin/bash -c 'cat /etc/slurm/slurm.conf.update \
   | pdsh -R mrsh -P <replaceable>partitions</replaceable> \
   "cat > /etc/slurm/slurm.conf"'
-&prompt;rm /etc/slurm/slurm.conf.update
-&prompt;scontrol reconfigure
-</screen>
+ &prompt;rm /etc/slurm/slurm.conf.update
+ &prompt;scontrol reconfigure
+ </screen>
           </step>
           <step>
            <para>
             Verify that the reconfiguration took effect:
            </para>
-<screen>&prompt;scontrol show config | grep Timeout</screen>
+           <screen>&prompt;scontrol show config | grep Timeout</screen>
           </step>
          </substeps>
         </step>
@@ -1177,8 +629,8 @@ SlurmdTimeout=3600</screen>
       </step>
       <step>
        <para>
-        <emphasis role="bold">Shut down any running
-        <literal>slurmctld</literal> instances</emphasis>
+        <emphasis role="bold">Shut down any running <literal>slurmctld</literal>
+        instances</emphasis>
        </para>
        <substeps>
         <step>
@@ -1186,41 +638,40 @@ SlurmdTimeout=3600</screen>
           If applicable, shut down any backup controllers on the backup head
           nodes:
          </para>
-<screen>&prompt_backup;systemctl stop slurmctld</screen>
+         <screen>&prompt_backup;systemctl stop slurmctld</screen>
         </step>
         <step>
          <para>
           Shut down the master controller:
          </para>
-<screen>&prompt_master;systemctl stop slurmctld</screen>
+ <screen>&prompt_master;systemctl stop slurmctld</screen>
         </step>
        </substeps>
       </step>
       <step>
        <para>
-        <emphasis role="bold">Back up the <literal>slurmctld</literal> state
-        files</emphasis>
+        <emphasis role="bold">Back up the <literal>slurmctld</literal> state files</emphasis>
        </para>
        <para>
         Also, it should be noted, that <literal>slurmctld</literal> maintains
         state information that is persistent. Almost every major version
-        involves changes to the <literal>slurmctld</literal> state files. This
-        state information will be upgraded as well if the upgrade remains
+        involves changes to the <literal>slurmctld</literal> state files.
+        This state information will be upgraded as well if the upgrade remains
         within the supported version range and no data will be lost.
        </para>
        <para>
-        However, if a downgrade should become necessary, state information from
-        newer versions will not be recognized by an older version of
-        <literal>slurmctld</literal> and thus will be discarded, resulting in a
-        loss of all running and pending jobs. Thus it is useful to back up the
-        old state in case an update needs to be rolled back.
+        However, if a downgrade should become necessary, state information
+        from newer versions will not be recognized by an older version of
+        <literal>slurmctld</literal> and thus will be discarded, resulting in a loss of all
+        running and pending jobs. Thus it is useful to back up the old state
+        in case an update needs to be rolled back.
        </para>
        <substeps>
         <step>
          <para>
           Determine the <literal>StateSaveLocation</literal> directory:
          </para>
-<screen>&prompt;scontrol show config | grep StateSaveLocation</screen>
+ <screen>&prompt;scontrol show config | grep StateSaveLocation</screen>
         </step>
         <step>
          <para>
@@ -1228,38 +679,37 @@ SlurmdTimeout=3600</screen>
           back the update if an issue arises.
          </para>
          <para>
-          Should a downgrade be required make sure to restore the content of
-          the <literal>StateSaveLocation</literal> directory from this backup.
+          Should a downgrade be required, make sure to restore the content of the
+          <literal>StateSaveLocation</literal> directory from this backup.
          </para>
         </step>
        </substeps>
       </step>
       <step>
        <para>
-        <emphasis role="bold">Shut down <literal>slurmd</literal> on the
-        nodes</emphasis>
+        <emphasis role="bold">Shut down <literal>slurmd</literal> on the nodes</emphasis>
        </para>
-<screen>&prompt;pdsh -R ssh -P <replaceable>partitions</replaceable> systemctl stop slurmd</screen>
+ <screen>&prompt;pdsh -R ssh -P <replaceable>partitions</replaceable> systemctl stop slurmd</screen>
       </step>
       <step>
        <para>
-        <emphasis role="bold">Update <literal>slurmctld</literal> on the master
-        and backup nodes as well as <literal>slurmd</literal> on the compute
-        nodes</emphasis>
+        <emphasis role="bold">Update <literal>slurmctld</literal> on the
+        master and backup nodes as well as <literal>slurmd</literal> on the
+        compute nodes</emphasis>
        </para>
        <substeps>
         <step>
          <para>
-          On the master/backup node(s): run:
+          On the master/backup node(s), run:
          </para>
-<screen>&prompt_master;zypper zypper install \
+ <screen>&prompt_master;zypper install \
   --force-resolution slurm_<replaceable>version</replaceable></screen>
         </step>
         <step>
          <para>
-          On the master node run:
+          On the master node, run:
          </para>
-<screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
+ <screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
   zypper install --force-resolution \
   slurm_<replaceable>version</replaceable>-node</screen>
         </step>
@@ -1270,22 +720,25 @@ SlurmdTimeout=3600</screen>
         <emphasis role="bold">Replace deprecated options</emphasis>
        </para>
        <para>
-        If deprecated options are to be replaced in the configuration files
-        (see list below), this may be performed before updating the services.
-        These configuration files may be distributed to all controllers and
-        nodes of the cluster by using the method as described in 3.b.bb above.
+        If deprecated options need to be replaced in the configuration files,
+        <!-- (see the list in <xref linkend="package-slurm-configuration-change"/>)
+        SP3 equivalent: https://www.suse.com/releasenotes/x86_64/SLE-HPC/15-SP3/#_deprecation_of_packages -->
+        this can be performed before updating the services. These
+        configuration files can be distributed to all controllers and nodes of
+        the cluster by using the method described in
+        <xref linkend="st-slurm-configuration-distribute"/>.
        </para>
        <note>
-        <title>Memory size seen by <literal>slurmd</literal> may change on update</title>
+        <title>Memory Size Seen by <literal>slurmd</literal> Can Change on Update</title>
         <para>
          Under certain circumstances, the amount of memory seen by
-         <literal>slurmd</literal> may change after an update. If this happens,
-         <literal>slurmctld</literal> will put the nodes in a
-         <literal>drained</literal> state. To check, whether the amount of
+         <literal>slurmd</literal> can change after an update. If this
+         happens, <literal>slurmctld</literal> will put the nodes
+         in a <literal>drained</literal> state. To check whether the amount of
          memory seem by <literal>slurmd</literal> will change after the update,
-         you may run on a single compute node:
+         run the following on a single compute node:
         </para>
-<screen>&prompt_node1;slurmd -C</screen>
+ <screen>&prompt_node1;slurmd -C</screen>
         <para>
          Compare the output with the settings in
          <filename>slurm.conf</filename>. If required, correct the setting.
@@ -1298,42 +751,40 @@ SlurmdTimeout=3600</screen>
         nodes</emphasis>
        </para>
        <para>
-        On the master controller run:
+        On the master controller, run:
        </para>
-<screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
+ <screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
   systemctl start slurmd</screen>
        <para>
         On the master, run:
        </para>
-<screen>&prompt_master;systemctl start slurmctld</screen>
+ <screen>&prompt_master;systemctl start slurmctld</screen>
        <para>
-        then execute the same on the backup controller(s)
+        Then execute the same on the backup controller(s).
        </para>
       </step>
       <step>
        <para>
-        <emphasis role="bold">Verify if the system operates properly</emphasis>
+        <emphasis role="bold">Verify whether the system operates properly</emphasis>
        </para>
        <substeps>
         <step>
          <para>
-          Check the status of the controller(s). On the master and backup
-          controllers, run:
+          Check the status of the controller(s).
          </para>
-<screen>&prompt;systemctl status slurmctld</screen>
+         <para>
+          On the master and backup controllers, run:
+         </para>
+ <screen>&prompt;systemctl status slurmctld</screen>
         </step>
         <step>
          <para>
-          and verify that the services are running without errors.
+          Verify that the services are running without errors using:
          </para>
+ <screen>sinfo -R</screen>
          <para>
-          Run:
-         </para>
-<screen>sinfo -R</screen>
-         <para>
-          to check whether there are any <literal>down</literal>,
-          <literal>drained</literal>, <literal>failing</literal> or
-          <literal>failed</literal> nodes after restart.
+          You will see whether there are any down, drained, failing, or
+          failed nodes after the restart.
          </para>
         </step>
        </substeps>
@@ -1347,108 +798,138 @@ SlurmdTimeout=3600</screen>
         <literal>SlurmctldTimeout</literal> values in
         <literal>/etc/slurm/slurm.conf</literal> on all nodes and run
         <literal>scontrol reconfigure</literal> (see
-        <xref
-         linkend="st-slurm-timeout"/>).
+        <xref linkend="st-slurm-timeout"/>).
        </para>
       </step>
      </substeps>
     </step>
    </procedure>
    <para>
-    A new major version of <package>libslurm</package> is provided with each
-    service pack of &product;. The old version will not be uninstalled on
-    upgrade, and user-provided applications built with an old version should
-    continue to work if the old library used is not older than the past two
-    versions. It is strongly recommended to rebuild local applications using
-    <literal>libslurm</literal> &mdash; such as MPI libraries with Slurm
-    support &mdash; as early as possible. This may require updating the user
-    applications, as new arguments may be introduced to existing functions.
+    Each service pack of &product; includes a new major version of
+    <literal>libslurm</literal>.
+    The old version will not be uninstalled on upgrade.
+    User-provided applications will work, as long as the library version used
+    for building is no more than two major versions behind.
+    We strongly recommend rebuilding local applications using
+    libslurm&mdash;such as MPI libraries with Slurm support&mdash;as early as
+    possible.
+    This can require updating user application if new arguments were
+    introduced to existing functions.
    </para>
-  </sect2>
- </sect1>
- <sect1 xml:id="sec-slurm-additional-res">
-  <title>Additional resources</title>
-
-  <sect2 xml:id="sec-slurm-faq">
-   <title>Frequently asked questions</title>
-   <qandaset>
-    <qandaentry>
-     <question>
+  </section>
+ </section>
+ <section xml:id="sec-pam_slurm_adopt">
+  <title>Enabling the <literal>pam_slurm_adopt</literal> Module</title>
+  <para>
+   The <literal>pam_slurm_adopt</literal> module allows restricting access to
+   compute nodes to those users that have jobs running on them. It can also
+   take care of <emphasis>run-away processes</emphasis> from user's jobs and
+   end these processes when the job has finished.
+  </para>
+  <para>
+   <literal>pam_slurm_adopt</literal> works by binding the login process
+   of a user and all its child processes to the <literal>cgroup</literal>
+   of a running job.
+  </para>
+  <para>
+   It can be enabled with following steps:
+  </para>
+  <procedure>
+   <step>
+    <para>
+     In the configuration file <filename>slurm.conf</filename>, set the option
+     <literal>PrologFlags=contain</literal>.
+    </para>
+    <para>
+     Make sure the option <literal>ProctrackType=proctrack/cgroup</literal>
+     is also set.
+    </para>
+   </step>
+   <step>
+    <para>
+     Restart the services
+     <systemitem class="daemon">slurmctld</systemitem> and
+     <systemitem class="daemon">slurmd</systemitem>.
+    </para>
+    <para>
+     For this change to take effect, it is not sufficient to issue the command
+     <command>scontrol reconfigure</command>.
+    </para>
+   </step>
+   <step>
+    <!-- FIXME: Does limiting apply to CPU use only? -->
+    <para>
+     Decide whether to limit resources:
+    </para>
+    <itemizedlist>
+     <listitem>
       <para>
-       How do I change the state of a node from <literal>down</literal> to
-       <literal>up</literal>?
+       If resources are not limited, user processes can continue running on
+       a node even after the job to which they were bound has finished.
       </para>
-     </question>
-     <answer>
+     </listitem>
+     <listitem>
       <para>
-       When the <literal>slurmd</literal> daemon on a node does not reboot in
-       the time specified in the <literal>ResumeTimeout</literal> parameter, or
-       the <literal>ReturnToService</literal> was not changed in the
-       configuration file <filename>slurm.conf</filename>, compute nodes stay
-       in the <literal>down</literal> state and have to be set back to the
-       <literal>up</literal> state manually. This can be done for the
-       <replaceable>NODE</replaceable> with the following command:
-      </para>
-<screen>scontrol update state=resume NodeName=<replaceable>NODE</replaceable></screen>
-     </answer>
-    </qandaentry>
-    <qandaentry>
-     <question>
-      <para>
-       What is the difference between the states <literal>down</literal> and
-       <literal>down*</literal>?
-      </para>
-     </question>
-     <answer>
-      <para>
-       A <literal>*</literal> shown after a status code means that the node is
-       not responding.
+       If resources are limited using a <literal>cgroup</literal>, user
+       processes will be killed when the job finishes, and the controlling
+       <literal>cgroup</literal> is deactivated.
       </para>
       <para>
-       Thus, when a node is marked as <literal>down*</literal>, it means that
-       the node is not reachable due to network issues, or that
-       <literal>slurmd</literal> is not running on that node.
+       To activate resource limits via a <literal>cgroup</literal>, in the
+       file <filename>/etc/slurm/cgroup.conf</filename>, set the option
+       <literal>ConstrainCores=yes</literal>.
       </para>
-      <para>
-       In the <literal>down</literal> state, the node is reachable, but either
-       the node was rebooted unexpectedly, the hardware does not match the
-       description in <filename>slurm.conf</filename>, or a health check was
-       configured with the <literal>HealthCheckProgram</literal>.
-      </para>
-     </answer>
-    </qandaentry>
-    <qandaentry>
-     <question>
-      <para>
-       How do I get the exact core count, socket number and number of CPUs for
-       a node?
-      </para>
-     </question>
-     <answer>
-      <para>
-       The values for a node which go into the configuration file
-       <filename>slurm.conf</filename> can be obtained with the command:
-      </para>
-<screen>slurmd -C</screen>
-     </answer>
-    </qandaentry>
-   </qandaset>
-  </sect2>
-
-  <sect2 xml:id="sec-slurm-ext-doc">
-   <title>External documentation</title>
-   <para>
-    For further documentation, see the
-    <link
-     xlink:href="https://slurm.schedmd.com/quickstart_admin.html">Quick
-    Start Administrator Guide</link> and
-    <link
-     xlink:href="https://slurm.schedmd.com/quickstart.html"> Quick
-    Start User Guide</link>. There is further in-depth documentation on the
-    <link
-     xlink:href="https://slurm.schedmd.com/documentation.html">Slurm
-    documentation page</link>.
-   </para>
-  </sect2>
- </sect1>
+     </listitem>
+    </itemizedlist>
+    <para>
+     Due to the complexity of accurately determining RAM requirements of jobs,
+     limiting the RAM space is not recommended.
+    </para>
+   </step>
+   <step>
+    <para>
+     Install the package <package>slurm-pam_slurm</package>:
+    </para>
+    <screen>zypper install slurm-pam_slurm</screen>
+   </step>
+   <step performance="optional">
+    <para>
+     You can disallow logins by users who have no running job in the machine:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <formalpara>
+       <title>Disabling SSH Logins Only:</title>
+       <para>
+        In the file <literal>/etc/pam.d/ssh</literal>, add the option:
+       </para>
+      </formalpara>
+      <screen>account     required pam_slurm_adopt.so</screen>
+     </listitem>
+     <listitem>
+      <formalpara>
+       <title>Disabling All Types of Logins:</title>
+       <para>
+        In the file <filename>/etc/pam.d/common-account</filename>, add the
+        option:
+       </para>
+      </formalpara>
+      <screen>account    required pam_slurm_adopt.so</screen>
+     </listitem>
+    </itemizedlist>
+   </step>
+  </procedure>
+ </section>
+ <section xml:id="sec-slurm-more-information">
+  <title>For More Information</title>
+  <para>
+   For further documentation, see the
+   <link xlink:href="https://slurm.schedmd.com/quickstart_admin.html">Quick Start
+   Administrator Guide</link> and
+   <link xlink:href="https://slurm.schedmd.com/quickstart.html">Quick Start User
+   Guide</link>. There is further in-depth documentation on the
+   <link xlink:href="https://slurm.schedmd.com/documentation.html">Slurm
+   documentation page</link>.
+  </para>
+ </section>
 </chapter>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -229,7 +229,7 @@ systemctl enable slurmd.service</screen>
    <para>
     To upgrade the package <package>slurm</package> to 18.08, run the command:
    </para>
-   <screen>zypper install --force-resolution slurm_18_08</screen>
+<screen>zypper install --force-resolution slurm_18_08</screen>
    <para>
     To upgrade &slurm; subpackages, proceed analogously.
    </para>
@@ -363,7 +363,7 @@ systemctl enable slurmd.service</screen>
    <para>
     If this is not the case, install <literal>pdsh</literal>:
    </para>
- <screen>&prompt;zypper in pdsh-slurm</screen>
+<screen>&prompt;zypper in pdsh-slurm</screen>
    <para>
     If you are not using <literal>mrsh</literal> in the cluster, the SSH
     back-end for <literal>pdsh</literal> can also be used for this. Replace the
@@ -411,11 +411,11 @@ systemctl enable slurmd.service</screen>
        <para>
         Stop the <literal>slurmdbd</literal> service:
        </para>
-       <screen>&prompt;rcslurmdbd stop</screen>
+<screen>&prompt;rcslurmdbd stop</screen>
        <para>
         Make sure that <literal>slurmdbd</literal> is not running anymore:
        </para>
-       <screen>&prompt;rcslurmdbd status</screen>
+<screen>&prompt;rcslurmdbd status</screen>
        <para>
         It should be noted that <literal>slurmctld</literal> might remain running
         while the database daemon is down. While it is down, requests intended
@@ -428,12 +428,12 @@ systemctl enable slurmd.service</screen>
        <para>
         Create a backup of the <literal>slurm_acct_db</literal> database:
        </para>
-       <screen>&prompt;mysqldump -p slurm_acct_db &gt; slurm_acct_db.sql</screen>
+<screen>&prompt;mysqldump -p slurm_acct_db &gt; slurm_acct_db.sql</screen>
        <note role="compact">
         <para>
          If needed, this can be restored by running:
         </para>
-        <screen>&prompt;mysql -p slurm_acct_db &lt; slurm_acct_db.sql</screen>
+<screen>&prompt;mysql -p slurm_acct_db &lt; slurm_acct_db.sql</screen>
        </note>
       </step>
       <step>
@@ -445,26 +445,26 @@ systemctl enable slurmd.service</screen>
        <para>
         On the database server, run:
        </para>
- <screen>&prompt;echo  'SELECT @@innodb_buffer_pool_size/1024/1024;' | \
+<screen>&prompt;echo  'SELECT @@innodb_buffer_pool_size/1024/1024;' | \
   mysql --password --batch</screen>
        <para>
         If the size is less than 128&nbsp;MB, it can be changed on the fly for the
         current session (on <literal>mariadb</literal>):
        </para>
- <screen>&prompt;echo 'set GLOBAL innodb_buffer_pool_size = 134217728;' | \
+<screen>&prompt;echo 'set GLOBAL innodb_buffer_pool_size = 134217728;' | \
   mysql --password --batch</screen>
        <para>
         Alternatively, the size can be changed permanently by editing
         <filename>/etc/my.cnf</filename> and setting it to 128&nbsp;MB.
         Then restart the database:
        </para>
-       <screen>&prompt;rcmysql restart</screen>
+<screen>&prompt;rcmysql restart</screen>
       </step>
       <step xml:id="st-slurm-install-slurmdbd">
        <para>
         Install the upgrade of <literal>slurmdbd</literal>:
        </para>
-       <screen>zypper install --force-resolution slurm_<replaceable>version</replaceable>-slurmdbd</screen>
+<screen>zypper install --force-resolution slurm_<replaceable>version</replaceable>-slurmdbd</screen>
        <note>
         <title>Update MariaDB Separately</title>
         <para>
@@ -479,14 +479,14 @@ systemctl enable slurmd.service</screen>
          <para>
           Upgrade MariaDB:
          </para>
-         <screen>&prompt;zypper update mariadb</screen>
+<screen>&prompt;zypper update mariadb</screen>
         </step>
         <step>
          <para>
           Run the conversion of the database tables to the new version of
           MariaDB:
          </para>
-         <screen>mysql_upgrade --user=root --password=<replaceable>root_db_password</replaceable>;</screen>
+<screen>mysql_upgrade --user=root --password=<replaceable>root_db_password</replaceable>;</screen>
         </step>
        </substeps>
       </step>
@@ -500,12 +500,12 @@ systemctl enable slurmd.service</screen>
         to perform the migration manually by running
         <literal>slurmdbd</literal> from the command line in the foreground:
        </para>
- <screen>&prompt;/usr/sbin/slurmdbd -D -v</screen>
+<screen>&prompt;/usr/sbin/slurmdbd -D -v</screen>
        <para>
         When you see the below message, <literal>slurmdbd</literal> can be shut
         down:
        </para>
- <screen>Conversion done:
+<screen>Conversion done:
  success!</screen>
        <para>
          To do so, use signal <literal>SIGTERM</literal> (that is, press
@@ -590,7 +590,7 @@ systemctl enable slurmd.service</screen>
           node and set the values for this variable to at least
           <literal>3600</literal> (1 hour).
          </para>
- <screen>&slurm;ctldTimeout=3600
+<screen>&slurm;ctldTimeout=3600
  &slurm;dTimeout=3600</screen>
         </step>
         <step xml:id="st-slurm-configuration-distribute">
@@ -609,7 +609,7 @@ systemctl enable slurmd.service</screen>
            <para>
             Execute:
            </para>
- <screen>&prompt;cp /etc/slurm/slurm.conf /etc/slurm/slurm.conf.update
+<screen>&prompt;cp /etc/slurm/slurm.conf /etc/slurm/slurm.conf.update
  &prompt;sudo -u slurm /bin/bash -c 'cat /etc/slurm/slurm.conf.update \
   | pdsh -R mrsh -P <replaceable>partitions</replaceable> \
   "cat > /etc/slurm/slurm.conf"'
@@ -621,7 +621,7 @@ systemctl enable slurmd.service</screen>
            <para>
             Verify that the reconfiguration took effect:
            </para>
-           <screen>&prompt;scontrol show config | grep Timeout</screen>
+<screen>&prompt;scontrol show config | grep Timeout</screen>
           </step>
          </substeps>
         </step>
@@ -638,13 +638,13 @@ systemctl enable slurmd.service</screen>
           If applicable, shut down any backup controllers on the backup head
           nodes:
          </para>
-         <screen>&prompt_backup;systemctl stop slurmctld</screen>
+<screen>&prompt_backup;systemctl stop slurmctld</screen>
         </step>
         <step>
          <para>
           Shut down the master controller:
          </para>
- <screen>&prompt_master;systemctl stop slurmctld</screen>
+<screen>&prompt_master;systemctl stop slurmctld</screen>
         </step>
        </substeps>
       </step>
@@ -671,7 +671,7 @@ systemctl enable slurmd.service</screen>
          <para>
           Determine the <literal>StateSaveLocation</literal> directory:
          </para>
- <screen>&prompt;scontrol show config | grep StateSaveLocation</screen>
+<screen>&prompt;scontrol show config | grep StateSaveLocation</screen>
         </step>
         <step>
          <para>
@@ -689,7 +689,7 @@ systemctl enable slurmd.service</screen>
        <para>
         <emphasis role="bold">Shut down <literal>slurmd</literal> on the nodes</emphasis>
        </para>
- <screen>&prompt;pdsh -R ssh -P <replaceable>partitions</replaceable> systemctl stop slurmd</screen>
+<screen>&prompt;pdsh -R ssh -P <replaceable>partitions</replaceable> systemctl stop slurmd</screen>
       </step>
       <step>
        <para>
@@ -702,14 +702,14 @@ systemctl enable slurmd.service</screen>
          <para>
           On the master/backup node(s), run:
          </para>
- <screen>&prompt_master;zypper install \
+<screen>&prompt_master;zypper install \
   --force-resolution slurm_<replaceable>version</replaceable></screen>
         </step>
         <step>
          <para>
           On the master node, run:
          </para>
- <screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
+<screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
   zypper install --force-resolution \
   slurm_<replaceable>version</replaceable>-node</screen>
         </step>
@@ -738,7 +738,7 @@ systemctl enable slurmd.service</screen>
          memory seem by <literal>slurmd</literal> will change after the update,
          run the following on a single compute node:
         </para>
- <screen>&prompt_node1;slurmd -C</screen>
+<screen>&prompt_node1;slurmd -C</screen>
         <para>
          Compare the output with the settings in
          <filename>slurm.conf</filename>. If required, correct the setting.
@@ -753,12 +753,12 @@ systemctl enable slurmd.service</screen>
        <para>
         On the master controller, run:
        </para>
- <screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
+<screen>&prompt_master;pdsh -R ssh -P <replaceable>partitions</replaceable> \
   systemctl start slurmd</screen>
        <para>
         On the master, run:
        </para>
- <screen>&prompt_master;systemctl start slurmctld</screen>
+<screen>&prompt_master;systemctl start slurmctld</screen>
        <para>
         Then execute the same on the backup controller(s).
        </para>
@@ -775,13 +775,13 @@ systemctl enable slurmd.service</screen>
          <para>
           On the master and backup controllers, run:
          </para>
- <screen>&prompt;systemctl status slurmctld</screen>
+<screen>&prompt;systemctl status slurmctld</screen>
         </step>
         <step>
          <para>
           Verify that the services are running without errors using:
          </para>
- <screen>sinfo -R</screen>
+<screen>sinfo -R</screen>
          <para>
           You will see whether there are any down, drained, failing, or
           failed nodes after the restart.
@@ -889,7 +889,7 @@ systemctl enable slurmd.service</screen>
     <para>
      Install the package <package>slurm-pam_slurm</package>:
     </para>
-    <screen>zypper install slurm-pam_slurm</screen>
+<screen>zypper install slurm-pam_slurm</screen>
    </step>
    <step performance="optional">
     <para>
@@ -903,7 +903,7 @@ systemctl enable slurmd.service</screen>
         In the file <literal>/etc/pam.d/ssh</literal>, add the option:
        </para>
       </formalpara>
-      <screen>account     required pam_slurm_adopt.so</screen>
+<screen>account     required pam_slurm_adopt.so</screen>
      </listitem>
      <listitem>
       <formalpara>
@@ -913,7 +913,7 @@ systemctl enable slurmd.service</screen>
         option:
        </para>
       </formalpara>
-      <screen>account    required pam_slurm_adopt.so</screen>
+<screen>account    required pam_slurm_adopt.so</screen>
      </listitem>
     </itemizedlist>
    </step>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -354,22 +354,22 @@ systemctl enable slurmd.service</screen>
   <section xml:id="sec-slurm-upgrade-workflow">
    <title>Upgrade Workflow</title>
    <para>
-    For this workflow it is assumed that
-    MUNGE authentication is used and that
-    <literal>pdsh</literal>, the <literal>pdsh</literal> &slurm; plugin and
+    For this workflow we assume that MUNGE authentication is in use and that
+    <literal>pdsh</literal>, the <literal>pdsh</literal> &slurm; plugin, and
     <literal>mrsh</literal> can be used to access all machines of the cluster.
-    That means, <literal>mrshd</literal> is running on all nodes in the cluster.
+    This means that <literal>mrshd</literal> should be running on all nodes in
+    the cluster.
    </para>
    <para>
     If this is not the case, install <literal>pdsh</literal>:
    </para>
  <screen>&prompt;zypper in pdsh-slurm</screen>
    <para>
-    If <literal>mrsh</literal> is not used in the cluster, the
-    SSH back-end for <literal>pdsh</literal> can be used as
-    well for this: Replace the option <literal>-R mrsh</literal> with
-    <literal>-R ssh</literal> in the <literal>pdsh</literal> commands below.
-    This is less scalable and you may run out of usable ports.
+    If you are not using <literal>mrsh</literal> in the cluster, the SSH
+    back-end for <literal>pdsh</literal> can also be used for this. Replace the
+    option <literal>-R mrsh</literal> with <literal>-R ssh</literal> in the
+    <literal>pdsh</literal> commands below. However, note that this is less
+    scalable and you may run out of usable ports.
    </para>
    <warning>
     <title>Upgrade <literal>slurmdbd</literal> databases before other &slurm; components</title>
@@ -377,11 +377,12 @@ systemctl enable slurmd.service</screen>
      If <literal>slurmdbd</literal> is used, always upgrade the
      <literal>slurmdbd</literal> database <emphasis>before</emphasis> starting
      the upgrade of any other &slurm; component.
-     The same database can be connected multiple clusters and must be upgraded
-     before all of them.
+     The same database can be connected to multiple clusters and must be
+     upgraded before all of them.
     </para>
     <para>
-     Upgrading other &slurm; components before the database can lead to data loss.
+     Upgrading other &slurm; components before the database can lead to data
+     loss.
     </para>
    </warning>
    <procedure xml:id="pro-slurm-upgrade-procedure">
@@ -393,19 +394,17 @@ systemctl enable slurmd.service</screen>
      <para>
       Upon the first start of <literal>slurmdbd</literal> after a
       <literal>slurmdbd</literal> upgrade, it will convert its database.
-      If the database is large, the conversion will take several 10s of minutes.
-      During this time, the database is not accessible.
+      If the database is large, the conversion will take several tens of
+      minutes. During this time, the database is not accessible.
      </para>
      <para>
       We strongly recommend creating a backup of the database in case an
-      error occurs during or after the upgrade process.
-      Without a backup, all accounting data collected in the database might
-      be lost in such an event.
-      A database
-      converted to a newer version cannot be converted back to an older one and
-      older versions of <literal>slurmdbd</literal> will not recognize the
-      newer formats. To back up and upgrade <literal>slurmdbd</literal>,
-      follow this procedure:
+      error occurs during or after the upgrade process. Without a backup, all
+      accounting data collected in the database might be lost in such an event.
+      A database converted to a newer version cannot be converted back to an
+      older one and older versions of <literal>slurmdbd</literal> will not
+      recognize the newer formats. To back up and upgrade
+      <literal>slurmdbd</literal>, follow this procedure:
      </para>
      <substeps>
       <step>
@@ -440,7 +439,8 @@ systemctl enable slurmd.service</screen>
       <step>
        <para>
         In preparation of the conversion, make sure the variable
-        <literal>innodb_buffer_size</literal> is set to a value &gt;= 128 Mb:
+        <literal>innodb_buffer_size</literal> is set to a value of 128&nbsp;MB
+        or higher:
        </para>
        <para>
         On the database server, run:
@@ -448,14 +448,14 @@ systemctl enable slurmd.service</screen>
  <screen>&prompt;echo  'SELECT @@innodb_buffer_pool_size/1024/1024;' | \
   mysql --password --batch</screen>
        <para>
-        If the size is less than 128 Mb, it can be changed on the fly for the
+        If the size is less than 128&nbsp;MB, it can be changed on the fly for the
         current session (on <literal>mariadb</literal>):
        </para>
  <screen>&prompt;echo 'set GLOBAL innodb_buffer_pool_size = 134217728;' | \
   mysql --password --batch</screen>
        <para>
         Alternatively, the size can be changed permanently by editing
-        <filename>/etc/my.cnf</filename> and setting it to 128 Mb.
+        <filename>/etc/my.cnf</filename> and setting it to 128&nbsp;MB.
         Then restart the database:
        </para>
        <screen>&prompt;rcmysql restart</screen>
@@ -729,7 +729,7 @@ systemctl enable slurmd.service</screen>
         <xref linkend="st-slurm-configuration-distribute"/>.
        </para>
        <note>
-        <title>Memory Size Seen by <literal>slurmd</literal> Can Change on Update</title>
+        <title>Memory size seen by <literal>slurmd</literal> can change on update</title>
         <para>
          Under certain circumstances, the amount of memory seen by
          <literal>slurmd</literal> can change after an update. If this
@@ -811,10 +811,9 @@ systemctl enable slurmd.service</screen>
     User-provided applications will work, as long as the library version used
     for building is no more than two major versions behind.
     We strongly recommend rebuilding local applications using
-    libslurm&mdash;such as MPI libraries with &slurm; support&mdash;as early as
-    possible.
-    This can require updating user application if new arguments were
-    introduced to existing functions.
+    <literal>libslurm</literal>&mdash;such as MPI libraries with &slurm;
+    support&mdash;as early as possible. This can require updating user
+    applications if new arguments were introduced to existing functions.
    </para>
   </section>
  </section>
@@ -823,7 +822,7 @@ systemctl enable slurmd.service</screen>
   <para>
    The <literal>pam_slurm_adopt</literal> module allows restricting access to
    compute nodes to those users that have jobs running on them. It can also
-   take care of <emphasis>run-away processes</emphasis> from user's jobs and
+   take care of <emphasis>runaway processes</emphasis> from users' jobs, and
    end these processes when the job has finished.
   </para>
   <para>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -12,11 +12,11 @@
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Slurm</title>
+ <title>&slurm;</title>
  <info>
   <abstract>
    <para>
-    Slurm is an open-source, fault-tolerant, and highly scalable cluster
+    &slurm; is an open-source, fault-tolerant, and highly scalable cluster
     management and job scheduling system for Linux clusters containing up to
     65,536 nodes. Components include machine status, partition management,
     job management, scheduling and accounting modules.
@@ -28,21 +28,21 @@
   </dm:docmanager>
  </info>
  <section xml:id="sec-slurm-install">
-  <title>Installing Slurm</title>
+  <title>Installing &slurm;</title>
   <para>
-   For a minimal setup to run Slurm with MUNGE support on
+   For a minimal setup to run &slurm; with MUNGE support on
    one control node and multiple compute nodes, follow these instructions:
   </para>
   <procedure>
    <step>
     <para>
-     Before installing Slurm, create a user and a group called
+     Before installing &slurm;, create a user and a group called
      <literal>slurm</literal>.
     </para>
     <important>
-     <title>Make Sure of Consistent UIDs and GIDs for Slurm's Accounts</title>
+     <title>Make Sure of Consistent UIDs and GIDs for &slurm;'s Accounts</title>
      <para>
-      For security reasons, Slurm does not run as the user
+      For security reasons, &slurm; does not run as the user
       <systemitem class="username">root</systemitem> but under its own
       user. It is important that the user
       <systemitem class="username">slurm</systemitem> has the
@@ -190,18 +190,18 @@ systemctl enable slurmd.service</screen>
   </section>
  </section>
  <section xml:id="sec-slurm-upgrade">
-  <title>Upgrading Slurm</title>
+  <title>Upgrading &slurm;</title>
   <section xml:id="sec-slurm-compatibility">
-   <title>Slurm Upgrade Compatibility</title>
+   <title>&slurm; Upgrade Compatibility</title>
    <para>
-    New major versions of Slurm are released in regular intervals. With some
+    New major versions of &slurm; are released in regular intervals. With some
     restrictions (see below), interoperability is guaranteed between 3 consecutive
     versions. However, unlike updates to maintenance releases (that is, releases
     which differ in the last version number), upgrades to newer major versions
     may require more careful planning.
    </para>
    <para>
-    For existing products under general support, version upgrades of Slurm are
+    For existing products under general support, version upgrades of &slurm; are
     provided regularly. Unlike maintenance updates, these upgrades will not be
     installed automatically using <literal>zypper patch</literal> but require the
     administrator to request their installation explicitly. This ensures
@@ -213,7 +213,7 @@ systemctl enable slurmd.service</screen>
     version.
    </para>
    <para>
-    Slurm uses a segmented version number: The first two segments denote the
+    &slurm; uses a segmented version number: The first two segments denote the
     major version, the final segment denotes the patch level.
    </para>
    <para>
@@ -231,11 +231,11 @@ systemctl enable slurmd.service</screen>
    </para>
    <screen>zypper install --force-resolution slurm_18_08</screen>
    <para>
-    To upgrade Slurm subpackages, proceed analogously.
+    To upgrade &slurm; subpackages, proceed analogously.
    </para>
    <important>
     <para>
-     If any additional Slurm packages are installed, make sure to upgrade those as well.
+     If any additional &slurm; packages are installed, make sure to upgrade those as well.
      These include:
     </para>
     <itemizedlist>
@@ -291,7 +291,7 @@ systemctl enable slurmd.service</screen>
      </listitem>
     </itemizedlist>
     <para>
-     All Slurm packages should be upgraded at the same time to avoid
+     All &slurm; packages should be upgraded at the same time to avoid
      conflicts between packages of different versions. This can be done by
      adding them to the <literal>zypper install</literal> command line
      described above.
@@ -328,7 +328,7 @@ systemctl enable slurmd.service</screen>
    <para>
     version(<literal>slurmdbd</literal>) &gt;=
     version(<literal>slurmctld</literal>) &gt;=
-    version(<literal>slurmd</literal>) &gt;= version (Slurm user CLIs).
+    version(<literal>slurmd</literal>) &gt;= version (&slurm; user CLIs).
    </para>
    <para>
     With each version, configuration options for
@@ -343,11 +343,11 @@ systemctl enable slurmd.service</screen>
     restarting a service.
    </para>
    <para>
-    It should be noted that a new major version of Slurm introduces a new version
+    It should be noted that a new major version of &slurm; introduces a new version
     of <literal>libslurm</literal>. Older versions of this library might no longer
-    work with an upgraded Slurm. For all &slea; software depending on
+    work with an upgraded &slurm;. For all &slea; software depending on
     <literal>libslurm </literal> an upgrade will be provided. Any locally
-    developed Slurm modules or tools might require modification and/or
+    developed &slurm; modules or tools might require modification and/or
     recompilation.
    </para>
   </section>
@@ -356,7 +356,7 @@ systemctl enable slurmd.service</screen>
    <para>
     For this workflow it is assumed that
     MUNGE authentication is used and that
-    <literal>pdsh</literal>, the <literal>pdsh</literal> Slurm plugin and
+    <literal>pdsh</literal>, the <literal>pdsh</literal> &slurm; plugin and
     <literal>mrsh</literal> can be used to access all machines of the cluster.
     That means, <literal>mrshd</literal> is running on all nodes in the cluster.
    </para>
@@ -372,20 +372,20 @@ systemctl enable slurmd.service</screen>
     This is less scalable and you may run out of usable ports.
    </para>
    <warning>
-    <title>Upgrade <literal>slurmdbd</literal> databases before other Slurm components</title>
+    <title>Upgrade <literal>slurmdbd</literal> databases before other &slurm; components</title>
     <para>
      If <literal>slurmdbd</literal> is used, always upgrade the
      <literal>slurmdbd</literal> database <emphasis>before</emphasis> starting
-     the upgrade of any other Slurm component.
+     the upgrade of any other &slurm; component.
      The same database can be connected multiple clusters and must be upgraded
      before all of them.
     </para>
     <para>
-     Upgrading other Slurm components before the database can lead to data loss.
+     Upgrading other &slurm; components before the database can lead to data loss.
     </para>
    </warning>
    <procedure xml:id="pro-slurm-upgrade-procedure">
-    <title>Upgrading Slurm</title>
+    <title>Upgrading &slurm;</title>
     <step>
      <para>
       <emphasis role="bold">Upgrade <literal>slurmdbd</literal> Database Daemon</emphasis>
@@ -549,7 +549,7 @@ systemctl enable slurmd.service</screen>
       <emphasis role="bold">Update slurmctld and slurmd</emphasis>
      </para>
      <para>
-      When the Slurm database has been updated, the
+      When the &slurm; database has been updated, the
       <literal>slurmctld</literal> and <literal>slurmd</literal>
       instances can be updated. We recommend updating the head and compute
       nodes all in a single pass. If this is not feasible, the compute nodes
@@ -565,7 +565,7 @@ systemctl enable slurmd.service</screen>
         configuration</emphasis>
        </para>
        <para>
-        It is advisable to create a backup copy of the Slurm configuration
+        It is advisable to create a backup copy of the &slurm; configuration
         before starting the upgrade process. Since the configuration file
         <literal>/etc/slurm/slurm.conf</literal> should be identical across the
         entire cluster, it is sufficient to do so on the master controller node.
@@ -576,8 +576,8 @@ systemctl enable slurmd.service</screen>
         <emphasis role="bold">Increase Timeouts</emphasis>
        </para>
        <para>
-        Set <literal>SlurmdTimeout</literal> and
-        <literal>SlurmctldTimeout</literal> in
+        Set <literal>&slurm;dTimeout</literal> and
+        <literal>&slurm;ctldTimeout</literal> in
         <literal>/etc/slurm/slurm.conf</literal> to sufficiently high values to
         avoid timeouts while <literal>slurmctld</literal> and
         <literal>slurmd</literal> are down. We recommend at least 60 minutes,
@@ -590,8 +590,8 @@ systemctl enable slurmd.service</screen>
           node and set the values for this variable to at least
           <literal>3600</literal> (1 hour).
          </para>
- <screen>SlurmctldTimeout=3600
- SlurmdTimeout=3600</screen>
+ <screen>&slurm;ctldTimeout=3600
+ &slurm;dTimeout=3600</screen>
         </step>
         <step xml:id="st-slurm-configuration-distribute">
          <para>
@@ -794,8 +794,8 @@ systemctl enable slurmd.service</screen>
         <emphasis role="bold">Clean up</emphasis>
        </para>
        <para>
-        Restore the <literal>SlurmdTimeout</literal> and
-        <literal>SlurmctldTimeout</literal> values in
+        Restore the <literal>&slurm;dTimeout</literal> and
+        <literal>&slurm;ctldTimeout</literal> values in
         <literal>/etc/slurm/slurm.conf</literal> on all nodes and run
         <literal>scontrol reconfigure</literal> (see
         <xref linkend="st-slurm-timeout"/>).
@@ -811,7 +811,7 @@ systemctl enable slurmd.service</screen>
     User-provided applications will work, as long as the library version used
     for building is no more than two major versions behind.
     We strongly recommend rebuilding local applications using
-    libslurm&mdash;such as MPI libraries with Slurm support&mdash;as early as
+    libslurm&mdash;such as MPI libraries with &slurm; support&mdash;as early as
     possible.
     This can require updating user application if new arguments were
     introduced to existing functions.
@@ -928,7 +928,7 @@ systemctl enable slurmd.service</screen>
    Administrator Guide</link> and
    <link xlink:href="https://slurm.schedmd.com/quickstart.html">Quick Start User
    Guide</link>. There is further in-depth documentation on the
-   <link xlink:href="https://slurm.schedmd.com/documentation.html">Slurm
+   <link xlink:href="https://slurm.schedmd.com/documentation.html">&slurm;
    documentation page</link>.
   </para>
  </section>


### PR DESCRIPTION
Per discussion with Liam, I've replaced the existing Slurm chapter with the Slurm section from the SP2 Release Notes. 

@lproven it is now yours to check out and update as necessary. 

I converted the section markup to chapter markup, and made a couple of very minor fixes. Otherwise, I've not changed any of the content. 

I included Enabling the pam_slurm_adopt Module from section 17.2 of the SP2 RNs, because it seemed relevant, but you can remove it if it's not necessary.

I commented out a couple of broken xrefs that were to another chapter in the SP2 release notes, and included what I think is the SP3 equivalent in the comment. Do with that what you think is best.