### PR TITLE
Add missing slurm parts from SP2 release notes

### DIFF
--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -1094,11 +1094,11 @@ Description="subgroup" Organization=bavaria</screen>
     <para>
      If <literal>slurmdbd</literal> is used, always upgrade the
      <literal>slurmdbd</literal> database <emphasis>before</emphasis> starting
-     the upgrade of any other Slurm component. The same database can be connected
+     the upgrade of any other &slurm; component. The same database can be connected
      to multiple clusters and must be upgraded before all of them.
     </para>
     <para>
-     Upgrading other Slurm components before the database can lead to data loss.
+     Upgrading other &slurm; components before the database can lead to data loss.
     </para>
    </warning>
    <procedure xml:id="pro-slurm-upgrade-workflow">

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -800,8 +800,8 @@ Description="subgroup" Organization=bavaria</screen>
   <para>
    The <literal>pam_slurm_adopt</literal> module allows restricting access to
    compute nodes to those users that have jobs running on them. It can also
-   take care of <emphasis>run-away processes</emphasis> from user's jobs and
-   end these processes when the job has finished.
+   take care of <emphasis>run-away processes</emphasis> from users' jobs and
+   end these processes when the jobs have finished.
   </para>
   <para>
    <literal>pam_slurm_adopt</literal> works by binding the login process
@@ -871,7 +871,7 @@ Description="subgroup" Organization=bavaria</screen>
    </step>
    <step performance="optional">
     <para>
-     You can disallow logins by users who have no running job in the machine:
+     You can disallow logins by users who have no running jobs on the machine:
     </para>
     <itemizedlist>
      <listitem>

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -845,7 +845,69 @@ Description="subgroup" Organization=bavaria</screen>
   <para>
    To upgrade Slurm subpackages, use the analogous commands.
   </para>
-
+  <important>
+   <para>
+    If any additional &slurm; packages are installed, make sure to upgrade
+    those as well. This includes:
+   </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       slurm-pam_slurm
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-sview
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       perl-slurm
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-lua
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-torque
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-config-man
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-doc
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-webdoc
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       slurm-auth-none
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       pdsh-slurm
+      </para>
+     </listitem>
+    </itemizedlist>
+    <para>
+     All &slurm; packages should be upgraded at the same time to avoid conflicts
+     between packages of different versions. This can be done by adding them to
+     the <literal>zypper install</literal> command line described above.
+   </para>
+  </important>
   <para>
    In addition to the <quote>three major-version rule</quote> mentioned at the
    beginning of this section, obey the following rules regarding the order of

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -795,6 +795,108 @@ Description="subgroup" Organization=bavaria</screen>
    </variablelist>
   </sect2>
  </sect1>
+ <sect1 xml:id="sec-pam-slurm-adopt">
+  <title>Enabling the <literal>pam_slurm_adopt</literal> Module</title>
+  <para>
+   The <literal>pam_slurm_adopt</literal> module allows restricting access to
+   compute nodes to those users that have jobs running on them. It can also
+   take care of <emphasis>run-away processes</emphasis> from user's jobs and
+   end these processes when the job has finished.
+  </para>
+  <para>
+   <literal>pam_slurm_adopt</literal> works by binding the login process
+   of a user and all its child processes to the <literal>cgroup</literal>
+   of a running job.
+  </para>
+  <para>
+   It can be enabled with following steps:
+  </para>
+  <procedure>
+   <step>
+    <para>
+     In the configuration file <filename>slurm.conf</filename>, set the option
+     <literal>PrologFlags=contain</literal>.
+    </para>
+    <para>
+     Make sure the option <literal>ProctrackType=proctrack/cgroup</literal>
+     is also set.
+    </para>
+   </step>
+   <step>
+    <para>
+     Restart the services
+     <systemitem class="daemon">slurmctld</systemitem> and
+     <systemitem class="daemon">slurmd</systemitem>.
+    </para>
+    <para>
+     For this change to take effect, it is not sufficient to issue the command
+     <command>scontrol reconfigure</command>.
+    </para>
+   </step>
+   <step>
+    <!-- FIXME: Does limiting apply to CPU use only? -->
+    <para>
+     Decide whether to limit resources:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       If resources are not limited, user processes can continue running on
+       a node even after the job to which they were bound has finished.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       If resources are limited using a <literal>cgroup</literal>, user
+       processes will be killed when the job finishes, and the controlling
+       <literal>cgroup</literal> is deactivated.
+      </para>
+      <para>
+       To activate resource limits via a <literal>cgroup</literal>, in the
+       file <filename>/etc/slurm/cgroup.conf</filename>, set the option
+       <literal>ConstrainCores=yes</literal>.
+      </para>
+     </listitem>
+    </itemizedlist>
+    <para>
+     Due to the complexity of accurately determining RAM requirements of jobs,
+     limiting the RAM space is not recommended.
+    </para>
+   </step>
+   <step>
+    <para>
+     Install the package <package>slurm-pam_slurm</package>:
+    </para>
+    <screen>zypper install slurm-pam_slurm</screen>
+   </step>
+   <step performance="optional">
+    <para>
+     You can disallow logins by users who have no running job in the machine:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <formalpara>
+       <title>Disabling SSH Logins Only:</title>
+       <para>
+        In the file <literal>/etc/pam.d/ssh</literal>, add the option:
+       </para>
+      </formalpara>
+      <screen>account     required pam_slurm_adopt.so</screen>
+     </listitem>
+     <listitem>
+      <formalpara>
+       <title>Disabling All Types of Logins:</title>
+       <para>
+        In the file <filename>/etc/pam.d/common-account</filename>, add the
+        option:
+       </para>
+      </formalpara>
+      <screen>account    required pam_slurm_adopt.so</screen>
+     </listitem>
+    </itemizedlist>
+   </step>
+  </procedure>
+ </sect1>
  <sect1 xml:id="sec-slurm-upgrade">
   <title>Upgrading Slurm</title>
 

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -411,7 +411,7 @@ Description="subgroup" Organization=bavaria</screen>
  </sect1>
  <sect1 xml:id="sec-slurm-adm-commands">
   <title>Slurm administration commands</title>
-
+<!-- https://slurm.schedmd.com/man_index.html -->
   <sect2 xml:id="sec-slurm-sconfigure">
    <title>scontrol</title>
    <para>
@@ -506,7 +506,7 @@ Description="subgroup" Organization=bavaria</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>reconfigure</term>
+     <term>scontrol reconfigure</term>
      <listitem>
       <para>
        will trigger a reload of the configuration file
@@ -515,7 +515,7 @@ Description="subgroup" Organization=bavaria</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>reboot <replaceable>NODELIST</replaceable></term>
+     <term>scontrol reboot <replaceable>NODELIST</replaceable></term>
      <listitem>
       <para>
        can be used to reboot a compute node, as soon as the jobs on it have

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -925,17 +925,23 @@ Description="subgroup" Organization=bavaria</screen>
     <literal>-R ssh</literal>in the <literal>pdsh</literal>commands below. This
     is less scalable and you may run out of usable ports.
    </para>
+   <warning>
+    <title>Upgrade <literal>slurmdbd</literal> databases before other &slurm; components</title>
+    <para>
+     If <literal>slurmdbd</literal> is used, always upgrade the
+     <literal>slurmdbd</literal> database <emphasis>before</emphasis> starting
+     the upgrade of any other Slurm component. The same database can be connected
+     to multiple clusters and must be upgraded before all of them.
+    </para>
+    <para>
+     Upgrading other Slurm components before the database can lead to data loss.
+    </para>
+   </warning>
    <procedure xml:id="pro-slurm-upgrade-workflow">
     <title>Upgrading Slurm</title>
     <step>
      <para>
-      <emphasis role="bold">Upgrade slurmdbd Database Daemon</emphasis>
-     </para>
-     <para>
-      If the database daemon <literal>slurmdbd</literal> is used, it must be
-      upgraded first. Care must be taken if the same database is used for
-      multiple clusters. The database needs to be updated before any cluster is
-      updated.
+      <emphasis role="bold">Upgrade <literal>slurmdbd</literal> Database Daemon</emphasis>
      </para>
      <para>
       It should be noted that when upgrading <literal>slurmdbd</literal>, a

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -795,7 +795,7 @@ Description="subgroup" Organization=bavaria</screen>
    </variablelist>
   </sect2>
  </sect1>
- <sect1 xml:id="sec-pam-slurm-adopt">
+ <!--sect1 xml:id="sec-pam-slurm-adopt">
   <title>Enabling the <literal>pam_slurm_adopt</literal> module</title>
   <para>
    The <literal>pam_slurm_adopt</literal> module allows restricting access to
@@ -834,7 +834,7 @@ Description="subgroup" Organization=bavaria</screen>
     </para>
    </step>
    <step>
-    <!-- FIXME: Does limiting apply to CPU use only? -->
+    <!- FIXME: Does limiting apply to CPU use only? ->
     <para>
      Decide whether to limit resources:
     </para>
@@ -896,7 +896,7 @@ Description="subgroup" Organization=bavaria</screen>
     </itemizedlist>
    </step>
   </procedure>
- </sect1>
+ </sect1-->
  <sect1 xml:id="sec-slurm-upgrade">
   <title>Upgrading Slurm</title>
 

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -796,7 +796,7 @@ Description="subgroup" Organization=bavaria</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-pam-slurm-adopt">
-  <title>Enabling the <literal>pam_slurm_adopt</literal> Module</title>
+  <title>Enabling the <literal>pam_slurm_adopt</literal> module</title>
   <para>
    The <literal>pam_slurm_adopt</literal> module allows restricting access to
    compute nodes to those users that have jobs running on them. It can also
@@ -876,7 +876,7 @@ Description="subgroup" Organization=bavaria</screen>
     <itemizedlist>
      <listitem>
       <formalpara>
-       <title>Disabling SSH Logins Only:</title>
+       <title>Disabling SSH logins only:</title>
        <para>
         In the file <literal>/etc/pam.d/ssh</literal>, add the option:
        </para>
@@ -885,7 +885,7 @@ Description="subgroup" Organization=bavaria</screen>
      </listitem>
      <listitem>
       <formalpara>
-       <title>Disabling All Types of Logins:</title>
+       <title>Disabling all types of logins:</title>
        <para>
         In the file <filename>/etc/pam.d/common-account</filename>, add the
         option:
@@ -1105,7 +1105,7 @@ Description="subgroup" Organization=bavaria</screen>
     <title>Upgrading Slurm</title>
     <step>
      <para>
-      <emphasis role="bold">Upgrade <literal>slurmdbd</literal> Database Daemon</emphasis>
+      <emphasis role="bold">Upgrade <literal>slurmdbd</literal> database daemon</emphasis>
      </para>
      <para>
       It should be noted that when upgrading <literal>slurmdbd</literal>, a


### PR DESCRIPTION
I went through the commits in the RNs SP2 branch, all the way back to December, and this is what I could find that wasn't in the Slurm chapter in this repo already.

(I also added the pam_slurm_adopt section because it seems relevant, and I didn't worry about a couple of may -> might fixes because I'll catch those in the overall revisions I have planned).

As far as I can tell, the other differences were all made intentionally in this repo (lots of updates from Christian last year). 

@sknorr @lproven please let me know if I've missed anything or added something I shouldn't have.