### PR TITLE
Fix spack setup command

### DIFF
--- a/xml/spack.xml
+++ b/xml/spack.xml
@@ -50,19 +50,19 @@
       <para>
        For bash/zsh/sh:
       </para>
-<screen>&prompt;. spack/share/spack/setup-env.sh</screen>
+<screen>&prompt;. /usr/share/spack/setup-env.sh</screen>
      </step>
      <step>
       <para>
        For tcsh/csh:
       </para>
-<screen>&prompt;source spack/share/spack/setup-env.csh</screen>
+<screen>&prompt;source /usr/share/spack/setup-env.csh</screen>
      </step>
      <step>
       <para>
        For fish:
       </para>
-<screen>&prompt;. spack/share/spack/setup-env.fish</screen>
+<screen>&prompt;. /usr/share/spack/setup-env.fish</screen>
      </step>
     </stepalternatives>
    </step>


### PR DESCRIPTION
### Description

Now that the fix for bsc#1191395 is available, the spack setup command works. However, it was slightly incorrect in the doc. That's now fixed.

### Are there any relevant issues/feature requests?

* bsc#1191395

### Which product versions do the changes apply to?

- [x] SLE HPC 15 SP4 *(current `main`, no backport necessary)*
- [x] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
