### PR TITLE
Add notes about automatically opened ports

### DIFF
--- a/xml/dolly.xml
+++ b/xml/dolly.xml
@@ -57,6 +57,13 @@
    Install dolly on the management server and all dolly client nodes:
   </para>
 <screen>&prompt;zypper in dolly</screen>
+<note>
+ <title>Automatically opened ports</title>
+ <para>
+  Installing the <package>dolly</package> package automatically opens the TCP
+  ports 9997 and 9998.
+ </para>
+</note>
   <para>
    The <command>dolly</command> command requires the following information,
    either directly on the command line or from a configuration file:

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -113,6 +113,13 @@
      </para>
     </step>
    </procedure>
+   <note>
+    <title>Automatically opened ports</title>
+    <para>
+     Installing the <package>slurm</package> package automatically opens the TCP
+     ports 6817, 6818, and 6819.
+    </para>
+   </note>
    <procedure xml:id="pro-configuring-slurm">
     <title>Configuring &slurm;</title>
     <step>


### PR DESCRIPTION
### Description

I added notes about which ports are opened when you install slurm and dolly.

### Are there any relevant issues/feature requests?

* jsc#SLE-22745

### Which product versions do the changes apply to?

- [x] SLE HPC 15 SP4 *(current `main`, no backport necessary)*
- [ ] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
