### PR TITLE
Remove additional packages for SLE-21366

### DIFF
--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -523,44 +523,6 @@
  <sect1 xml:id="FileFormat">
   <title>File format libraries</title>
 
-  <sect2 xml:id="sec2-lib-adios">
-   <title>Adaptable IO System (ADIOS)</title>
-   <para>
-    The Adaptable IO System (ADIOS) provides a flexible way for
-    scientists to describe the data in their code that might need to be written,
-    read, or processed outside of the running simulation. For more information,
-    see <link xlink:href="https://www.olcf.ornl.gov/center-projects/adios/"/>.
-   </para>
-   <para>
-    To load this module, run the following command:
-   </para>
-<screen>&prompt.user;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> adios</screen>
-   <para>
-    For information about the toolchain to load, see <xref
-    linkend="sec-compiler"/>. For information about available MPI flavors, see
-    <xref linkend="sec1-MPI-libs"/>.
-   </para>
-   <para>
-    List of master packages:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      <package>adios-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc</package>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <package>adios-gnu-<replaceable>MPI_FLAVOR</replaceable>-hpc-devel</package>
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-    Replace <replaceable>MPI_FLAVOR</replaceable> with one of the supported MPI
-    flavors described in <xref linkend="sec1-MPI-libs"/>.
-   </para>
-  </sect2>
-
   <sect2 xml:id="sec2-lib-hdf5">
    <title>HDF5 &hpca; library &mdash; model, library, and file format for storing and managing data</title>
    <para>

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -518,51 +518,8 @@
     </listitem>
    </itemizedlist>
   </sect2>
-
-  <sect2 xml:id="sec2-lib-superlu">
-   <title>SuperLU &mdash; supernodal LU decomposition of sparse matrices</title>
-   <!-- https://portal.nersc.gov/project/sparse/superlu/ -->
-   <para>
-    SuperLU is a general-purpose library for the direct solution of large,
-    sparse, nonsymmetric systems of linear equations. The library is written in
-    C and can be called from C and Fortran programs.
-   </para>
-   <para>
-    This library requires a compiler toolchain and an MPI flavor to be loaded
-    beforehand. To load this module, run the following command:
-   </para>
-<screen>&prompt.user;module load <replaceable>TOOLCHAIN</replaceable> superlu</screen>
-   <para>
-    For information about the toolchain to load, see <xref
-     linkend="sec-compiler"/>.
-   </para>
-   <para>
-    List of master packages:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      <literal>libsuperlu-gnu-hpc</literal>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <literal>superlu-gnu-hpc-devel</literal>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <literal>superlu-gnu-hpc-doc</literal>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <literal>superlu-gnu-hpc-examples</literal>
-     </para>
-    </listitem>
-   </itemizedlist>
-  </sect2>
  </sect1>
+
  <sect1 xml:id="FileFormat">
   <title>File format libraries</title>
 


### PR DESCRIPTION
### Description

Removed adios, and also removed superlu as I noticed it's gone from the SP4 column in the package comparison. 

I've left the adios example in the sec-compute-lib section, since I guess it still applies when people build it themselves. Let me know if I should remove it, though.

### Are there any relevant issues/feature requests?

* jsc#SLE-21366

### Which product versions do the changes apply to?

- [x] SLE HPC 15 SP4 *(current `main`, no backport necessary)*
- [ ] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
