### PR TITLE
remove -d option as it doesn't exist anymore

### DIFF
--- a/xml/dolly.xml
+++ b/xml/dolly.xml
@@ -376,12 +376,6 @@ endconfig<co xml:id="dolly-config-end"/></screen>
    </listitem>
    <listitem>
     <para>
-     <option>-d</option>: Dummy mode should only be used for benchmarking and
-     is not supported.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      <option>-c</option>: Specifying the uncompressed size of a compressed file
      should only be used for performance statistics.
     </para>


### PR DESCRIPTION
-d option will be used for another option, dummy mode has been removed

### Description

Describe this pull request.

### Are there any relevant issues/feature requests?

* bsc#...
* jsc#...

### Which product versions do the changes apply to?

- [ X] SLE HPC 15 SP4 *(current `main`, no backport necessary)*
- [ ] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
