### PR TITLE
Use suse2022-ns stylesheets for HPC en-us

### DIFF
--- a/DC-hpc-guide
+++ b/DC-hpc-guide
@@ -6,5 +6,5 @@ ROOTID=book-hpc
 PROFOS="sles"
 PROFCONDITION="suse-product"
 
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"


### PR DESCRIPTION
### Description

We want to switch to the new 3-column layout. This PR uses the new stylesheets.


### Which product versions do the changes apply to?

- [x] SLE HPC 15 SP4 *(current `main`)*:  91f9084
- [x] SLE HPC 15 SP3: 

