### PR TITLE
Add Warewulf procedure

### DIFF
--- a/xml/MAIN.hpc-guide.xml
+++ b/xml/MAIN.hpc-guide.xml
@@ -45,9 +45,7 @@
 
   <xi:include href="installation.xml"/>
 
- <!--
-  <xi:include href="deployment.xml"/>
- -->
+  <xi:include href="warewulf.xml"/>
 
   <xi:include href="remote_administration.xml"/>
 

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -43,3 +43,4 @@
 <!ENTITY prompt.mntr   "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>monitor # </prompt>">
 <!ENTITY prompt.db     "<prompt xmlns='http://docbook.org/ns/docbook'>sql &gt; </prompt>">
 <!ENTITY prompt.DBnode "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>DBnode # </prompt>">
+<!ENTITY prompt.wwcon  "<prompt xmlns='http://docbook.org/ns/docbook'>[hpcnode&productnumbershort;] &warewulf;&gt; </prompt>">

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -33,6 +33,7 @@
 <!ENTITY prometheus "Prometheus">
 <!ENTITY spack "Spack">
 <!ENTITY apptainer "Apptainer">
+<!ENTITY warewulf "Warewulf">
 
 <!-- HPC PROMPTS -->
 <!-- Plain prompts are also available from generic-entities.ent -->

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -399,4 +399,6 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
   <screen>&prompt.user;sudo echo "mrsh" &gt;&gt; /etc/securetty
 &prompt.user;sudo echo "mrlogin" &gt;&gt; /etc/securetty</screen>
  </sect1>
+
+ <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="warewulf.xml"/>
 </chapter>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -26,6 +26,9 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
+
+ <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="warewulf.xml"/>
+
  <sect1 xml:id="sec-remote-genders">
   <title>Genders &mdash; static cluster configuration database</title>
   <para>
@@ -399,6 +402,4 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
   <screen>&prompt.user;sudo echo "mrsh" &gt;&gt; /etc/securetty
 &prompt.user;sudo echo "mrlogin" &gt;&gt; /etc/securetty</screen>
  </sect1>
-
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="warewulf.xml"/>
 </chapter>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -27,8 +27,6 @@
   </dm:docmanager>
  </info>
 
- <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="warewulf.xml"/>
-
  <sect1 xml:id="sec-remote-genders">
   <title>Genders &mdash; static cluster configuration database</title>
   <para>

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -281,21 +281,92 @@ hpcnode&product-ga;.&product-sp; --setdefault</screen>
 
  <sect1 xml:id="sec-warewulf-advanced-tasks">
   <title>Advanced &warewulf; tasks</title>
-  <sect2>
-   <title>Creating, modifying, and specifying profiles</title>
-   <para></para>
+  <sect2 xml:id="sec-warewulf-secure-boot">
+   <title>Using &warewulf; with &uefisecboot;</title>
+   <para>
+    To boot compute nodes with &uefisecboot; enabled, the packages <package>shim</package>
+    and <package>grub2-x86_64-efi</package> must be installed in the &warewulf; container.
+    For the container you imported in <xref linkend="pro-warewulf-deploy-nodes"/>, this should
+    already be the default. Use the following procedure to verify that the packages are installed:
+   </para>
+   <procedure xml:id="pro-warewulf-secure-boot-packages">
+     <title>Verifying packages in a &warewulf; container</title>
+     <step>
+       <para>
+         Open a shell in the &warewulf; container:
+       </para>
+<screen>&prompt.user;sudo wwctl container shell hpcnode&productnumbershort;</screen>
+     </step>
+     <step>
+       <para>
+         Search for the packages and check their installation status in the
+         <literal>S</literal> column:
+       </para>
+<screen>&prompt.wwcon;zypper search shim grub2</screen>
+       <para>
+         If <package>shim</package> and <package>grub2-x86_64-efi</package> are not installed,
+         install them now:
+       </para>
+<screen>&prompt.wwcon;zypper install shim grub2-x86_64-efi</screen>
+     </step>
+     <step>
+       <para>
+        Exit the container's shell:
+       </para>
+<screen>&prompt.wwcon;exit</screen>
+       <para>
+        If any changes were made, &warewulf; automatically rebuilds the container.
+       </para>
+     </step>
+     <step>
+       <para>
+         We recommend rebuilding the container again manually to make sure the changes are applied:
+       </para>
+<screen>&prompt.user;sudo wwctl container build hpcnode&productnumbershort;</screen>
+     </step>
+   </procedure>
+   <para>
+    By default, &warewulf; boots nodes via iPXE, which cannot be used when &uefisecboot;
+    is enabled. Use the following procedure to switch to &grub; as the boot method:
+   </para>
+   <procedure xml:id="pro-warewulf-secure-boot-grub">
+     <title>Configuring &warewulf; to boot via &grub;</title>
+     <step>
+       <para>
+        Open the file <filename>/etc/warewulf/warewulf.conf</filename> and change the value of
+        <literal>grubboot</literal> to <literal>true</literal>:
+       </para>
+<screen>warewulf:
+  [...]
+  grubboot: true</screen>
+     </step>
+     <step>
+       <para>
+        Reconfigure DHCP and TFTP to recognize the configuration change:
+       </para>
+<screen>&prompt.user;sudo wwctl configure dhcp
+&prompt.user;sudo wwctl configure tftp</screen>
+     </step>
+     <step>
+       <para>
+        Rebuild the system and runtime overlays:
+       </para>
+<screen>&prompt.user;sudo wwctl overlay build</screen>
+     </step>
+   </procedure>
   </sect2>
-  <sect2>
-   <title>Creating and specifying overlays</title>
-   <para></para>
-  </sect2>
-  <sect2>
-   <title>Using &warewulf; with Secure Boot</title>
-   <para></para>
-  </sect2>
-  <sect2>
+  <sect2 xml:id="sec-warewulf-storage">
    <title>Configuring local node storage</title>
    <para></para>
+   <important role="compact">
+     <para>
+       I attempted to test this procedure but got <literal>No provider found</literal> for
+       <package>ignition</package>.
+     </para>
+     <para>
+       Searched SCC; ignition is only in Package Hub for 15 SP4 and earlier.
+     </para>
+   </important>
   </sect2>
  </sect1>
 

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -119,12 +119,20 @@
    </itemizedlist>
   </step>
   <step>
+    <para>
+      Importing the &warewulf; container from the &suse; registry requires &scc; credentials.
+      Set your credentials as environment variables before you import the container:
+    </para>
+<screen>&prompt.user;export WAREWULF_OCI_USERNAME=<replaceable>USER@EXAMPLE.COM</replaceable>
+&prompt.user;export WAREWULF_OCI_PASSWORD=<replaceable>REGISTRATION_CODE</replaceable></screen>
+  </step>
+  <step>
    <para>
-    Import a compute node container from the &suse; registry:
+    Import the &warewulf; container from the &suse; registry:
    </para>
 <screen>&prompt.user;sudo wwctl container import \
-docker://registry.suse.com/suse/containers/<remark>TBD</remark> \
-<remark>TBD</remark> --setdefault</screen>
+docker://registry.suse.com/suse/hpc/warewulf4-x86_64/sle-hpc-node:&product-ga;.&product-sp; \
+hpcnode&product-ga;.&product-sp; --setdefault</screen>
    <para>
     The <option>--setdefault</option> argument sets this as the default container
     in the <literal>default</literal> node profile.

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -20,9 +20,6 @@
   </dm:docmanager>
  </info>
 
-<remark>Control node vs control server vs controller host vs warewulf server??
- I've seen all these terms used... which one will we use?</remark>
-
  <para>
   &warewulf; is a node deployment system for &hpc; clusters. The compute nodes are booted
   over the network using PXE. &warewulf; configures DHCP and TFTP on the &warewulf; server
@@ -47,7 +44,7 @@
   <title>Requirements</title>
   <listitem>
    <para>
-    The &warewulf; control node has a static IP address.
+    The &warewulf; server has a static IP address.
    </para>
   </listitem>
   <listitem>
@@ -61,13 +58,13 @@
   <title>Deploying compute nodes with &warewulf;</title>
   <step>
    <para>
-    On the control node, install &warewulf;:
+    On the &warewulf; server, install &warewulf;:
    </para>
 <screen>&prompt.user;sudo zypper install warewulf4</screen>
   </step>
   <step>
    <para>
-    &warewulf; creates a basic configuration for the control node in the file
+    &warewulf; creates a basic configuration for the &warewulf; server in the file
     <filename>/etc/warewulf/warewulf.conf</filename>. Check this file to make sure
     the networking details are correct, or update the details if required.
    </para>
@@ -106,7 +103,7 @@
     </listitem>
     <listitem>
      <para>
-      Configures an NFS server on the control node and enables the NFS service.
+      Configures an NFS server on the &warewulf; server and enables the NFS service.
      </para>
     </listitem>
     <listitem>
@@ -150,7 +147,7 @@ docker://registry.suse.com/suse/containers/<remark>TBD</remark> \
     with preconfigured IP addresses, run the following command:
    </para>
 <screen>&prompt.user;sudo wwctl node add n[01-10] \ <co xml:id="co-warewulf-deploy-node-name"/>
---netdev eth0 -I &subnetI;.11 \ <co xml:id="co-warewulf-deploy-node-network"/>
+--netdev eth0 -I &subnetI;.100 \ <co xml:id="co-warewulf-deploy-node-network"/>
 --discoverable=true <co xml:id="co-warewulf-deploy-node-discover"/></screen>
    <calloutlist>
     <callout arearefs="co-warewulf-deploy-node-name">
@@ -164,10 +161,6 @@ docker://registry.suse.com/suse/containers/<remark>TBD</remark> \
      <para>
       The IP address for the first node. Subsequent nodes will be given incremental
       IP addresses.
-     </para>
-     <para>
-      <remark>Should this address be inside or outside the DHCP range? In the
-       internal doc it's inside the range but in the upstream doc it's outside the range.</remark>
      </para>
     </callout>
     <callout arearefs="co-warewulf-deploy-node-discover">
@@ -187,10 +180,6 @@ docker://registry.suse.com/suse/containers/<remark>TBD</remark> \
     Build the default system and runtime overlays for each node:
    </para>
 <screen>&prompt.user;sudo wwctl overlay build</screen>
-   <para>
-    <remark>Do we need to do this, or is it automatic and you only need to run
-     the command if you edit any overlays?</remark>
-   </para>
    <para>
     <remark>Are there any HPC-specific things that we should direct people to
      add to an overlay/create an overlay for?</remark>

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -20,23 +20,56 @@
   </dm:docmanager>
  </info>
 
+<remark>Control node vs control server vs controller host vs warewulf server??
+ I've seen all these terms used... which one will we use?</remark>
+
  <para>
-  <remark>Add info on &warewulf;, profiles, overlays, etc.</remark>
+  &warewulf; is a node deployment system for &hpc; clusters. The compute nodes are booted
+  over the network using PXE. &warewulf; configures DHCP and TFTP on the &warewulf; server
+  (or control node), and configures the compute nodes using <emphasis>node profiles</emphasis>
+  and <emphasis>&warewulf; overlays</emphasis>.
  </para>
  <para>
-  For more information, see <link xlink:href="https://warewulf.org/docs/"/>.
+  <emphasis>Node profiles</emphasis> group shared node configurations together, such as
+  the container or kernel, overlays, and IPMI settings. New nodes automatically use the
+  <literal>default</literal> node profile. You can also create additional node profiles,
+  for example, if two groups of nodes require different containers.
  </para>
+ <para>
+  <emphasis>&warewulf; overlays</emphasis> are compiled for each individual compute node.
+  System overlays (or <literal>wwinit</literal> overlays) are applied during boot and are
+  used for configuration that is node-specific, such as networking and services. Runtime
+  overlays are applied periodically while the node is running, and are used for configuration
+  that changes, such as users and groups.
+ </para>
+
+ <itemizedlist>
+  <title>Requirements</title>
+  <listitem>
+   <para>
+    The &warewulf; control node has a static IP address.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The compute nodes are set to PXE boot.
+   </para>
+  </listitem>
+ </itemizedlist>
+
  <procedure xml:id="pro-warewulf-deploy-nodes">
   <title>Deploying compute nodes with &warewulf;</title>
   <step>
    <para>
-    Install &warewulf;:
+    On the control node, install &warewulf;:
    </para>
 <screen>&prompt.user;sudo zypper install warewulf4</screen>
   </step>
   <step>
    <para>
-    Configure the controller host <remark>WIP</remark>
+    &warewulf; creates a basic configuration for the control node in the file
+    <filename>/etc/warewulf/warewulf.conf</filename>. Check this file to make sure
+    the networking details are correct, or update the details if required.
    </para>
   </step>
   <step>
@@ -47,7 +80,9 @@
   </step>
   <step>
    <para>
-    If the dhcpd service was not used before you will have to add the interface on which the cluster network is running to the DHCP_INTERFACE in the file /etc/sysconfig/dhcpd. <remark>WIP</remark>
+    If DHCP is not already in use on this node, add the interface on which
+    the cluster network is running to <option>DHCP_INTERFACE</option> in the
+    file <filename>/etc/sysconfig/dhcpd</filename>.
    </para>
   </step>
   <step>
@@ -56,8 +91,35 @@
    </para>
 <screen>&prompt.user;sudo wwctl configure --all</screen>
    <para>
-    <remark>Add description of what this does.</remark>
+    This command performs the following tasks:
    </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      Configures DHCP and enables the DHCP service.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Updates the <filename>/etc/hosts</filename> file.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Configures an NFS server on the control node and enables the NFS service.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Creates host keys and user keys for passwordless SSH access to the nodes.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Writes the required PXE files to the TFTP root directory and enables the TFTP service.
+     </para>
+    </listitem>
+   </itemizedlist>
   </step>
   <step>
    <para>
@@ -103,6 +165,10 @@ docker://registry.suse.com/suse/containers/<remark>TBD</remark> \
       The IP address for the first node. Subsequent nodes will be given incremental
       IP addresses.
      </para>
+     <para>
+      <remark>Should this address be inside or outside the DHCP range? In the
+       internal doc it's inside the range but in the upstream doc it's outside the range.</remark>
+     </para>
     </callout>
     <callout arearefs="co-warewulf-deploy-node-discover">
      <para>
@@ -118,16 +184,45 @@ docker://registry.suse.com/suse/containers/<remark>TBD</remark> \
   </step>
   <step>
    <para>
-    <remark>Do we need an actual step for overlays? Do you have to run <command>wwctl overlay build</command> before you boot the nodes, or is that only if you edited any overlays?</remark>
+    Build the default system and runtime overlays for each node:
+   </para>
+<screen>&prompt.user;sudo wwctl overlay build</screen>
+   <para>
+    <remark>Do we need to do this, or is it automatic and you only need to run
+     the command if you edit any overlays?</remark>
    </para>
    <para>
-    <remark>Is it possible to use overlays to do things like install &slurm;?</remark>
+    <remark>Are there any HPC-specific things that we should direct people to
+     add to an overlay/create an overlay for?</remark>
    </para>
   </step>
   <step>
    <para>
-    Boot the compute nodes via PXE.
+    Boot the compute nodes with PXE. &warewulf; provides all of the required information.
    </para>
   </step>
  </procedure>
+ <itemizedlist>
+  <title>For more information</title>
+  <listitem>
+   <para>
+    &warewulf;: <link xlink:href="https://warewulf.org/docs/development/index.html"/>
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Node profiles: <link xlink:href="https://warewulf.org/docs/development/contents/profiles.html"/>
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    &warewulf; overlays: <link xlink:href="https://warewulf.org/docs/development/contents/overlays.html"/>
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    The node provisioning process: <link xlink:href="https://warewulf.org/docs/development/contents/provisioning.html"/>
+   </para>
+  </listitem>
+ </itemizedlist>
 </sect1>

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -21,25 +21,52 @@
  </info>
 
  <para>
-  &warewulf; is a node deployment system for &hpc; clusters. Compute nodes are booted
-  over the network using a <emphasis>&warewulf; container</emphasis>, which is a node image
-  with a bootable kernel. &warewulf; configures DHCP and TFTP on the &warewulf; server,
-  and configures the compute nodes using <emphasis>node profiles</emphasis>
-  and <emphasis>&warewulf; overlays</emphasis>.
+  &warewulf; is a deployment system for compute nodes in &hpc; clusters. Compute nodes
+  are booted and deployed over the network with a kernel and node image provided by &warewulf;.
+  To generate the node image, &warewulf; uses a <emphasis>&warewulf; container</emphasis>,
+  which is a base operating system container with a kernel and an <literal>init</literal>
+  implementation installed. &warewulf; configures images for the individual compute nodes using
+  <emphasis>node profiles</emphasis> and <emphasis>&warewulf; overlays</emphasis>.
  </para>
  <para>
-  <emphasis>Node profiles</emphasis> are used to group configurations together so that they
-  can be applied to multiple nodes. Node profiles can include settings such as the container
+  <emphasis>Node profiles</emphasis> are used to apply the same configuration
+  to multiple nodes. Node profiles can include settings such as the container
   to use, overlays to apply, and IPMI details. New nodes automatically use the
   <literal>default</literal> node profile. You can also create additional node profiles,
   for example, if two groups of nodes require different containers.
  </para>
  <para>
-  <emphasis>&warewulf; overlays</emphasis> are compiled for each individual compute node.
-  System overlays (or <literal>wwinit</literal> overlays) are applied during boot and are
-  used for configuration that is node-specific, such as networking and services. Runtime
-  overlays are applied periodically while the node is running and are used for configuration
-  that changes, such as users and groups.
+  <emphasis>&warewulf; overlays</emphasis> are compiled for each individual compute node:
+ </para>
+ <itemizedlist>
+   <listitem>
+     <para>
+       System (or <literal>wwinit</literal>) overlays are applied to nodes at boot time
+       by the <literal>wwinit</literal> process, before &systemd; starts. These overlays
+       are required to start the compute nodes, and contain basic node-specific configuration
+       to start the first network interface. System overlays are not updated during runtime.
+     </para>
+   </listitem>
+   <listitem>
+     <para>
+       Runtime (or generic) overlays are updated periodically at runtime by the
+       <literal>wwclient</literal> service. The default is once per minute. These overlays
+       are used to apply configuration changes to the nodes.
+     </para>
+   </listitem>
+   <listitem>
+     <para>
+       The Host overlay is used for configuration that applies to the &warewulf; server
+       itself, such as adding entries to <filename>/etc/hosts</filename> or setting up the
+       DHCP service and NFS exports.
+     </para>
+   </listitem>
+ </itemizedlist>
+ <para>
+  System and runtime overlays can be overlayed on top of each other. For example, instead of
+  altering a configuration setting in an overlay, you can override it with a new overlay.
+  You can set a list of system and runtime overlays to apply to individual nodes, or to
+  multiple nodes via profiles.
  </para>
 
  <itemizedlist>
@@ -54,6 +81,14 @@
     The compute nodes are set to PXE boot.
    </para>
   </listitem>
+  <listitem>
+   <para>
+    The &warewulf; server is accessible from an external network, but is connected to
+    the compute nodes via an internal cluster network used for deployment. This is
+    important because &warewulf; configures DHCP and TFTP on the &warewulf; server,
+    which might conflict with DHCP on the external network.
+   </para>
+  </listitem>
  </itemizedlist>
 
  <procedure xml:id="pro-warewulf-deploy-nodes">
@@ -66,10 +101,24 @@
   </step>
   <step>
    <para>
-    &warewulf; creates a basic configuration for the &warewulf; server in the file
-    <filename>/etc/warewulf/warewulf.conf</filename>. Check this file to make sure
-    the networking details are correct, or update the details if required.
+    The installation creates a basic configuration for the &warewulf; server in the file
+    <filename>/etc/warewulf/warewulf.conf</filename>. Review this file to make sure
+    the details are correct. In particular, check the following settings:
    </para>
+<screen>ipaddr: &subnetI;.250
+netmask: &subnetmask;
+network: &subnetI;.0</screen>
+   <para>
+    <literal>ipaddr</literal> is the IP address of the &warewulf; server on the internal
+    cluster network to be used for node deployment. <literal>netmask</literal> and
+    <literal>network</literal> must match this network.
+   </para>
+   <para>
+    Additionally, check that the DHCP range is in the cluster network:
+   </para>
+<screen>dhcp:
+  range start: &subnetI;.21
+  range end: &subnetI;.50</screen>
   </step>
   <step>
    <para>
@@ -100,6 +149,11 @@
     </listitem>
     <listitem>
      <para>
+      Writes the required PXE files to the TFTP root directory and enables the TFTP service.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       Updates the <filename>/etc/hosts</filename> file.
      </para>
     </listitem>
@@ -113,17 +167,20 @@
       Creates host keys and user keys for passwordless SSH access to the nodes.
      </para>
     </listitem>
-    <listitem>
-     <para>
-      Writes the required PXE files to the TFTP root directory and enables the TFTP service.
-     </para>
-    </listitem>
    </itemizedlist>
   </step>
   <step>
    <para>
+    When the configuration is finished, log out of the &warewulf; server and back into it.
+    This creates an SSH key pair to allow passwordless login to the deployed compute nodes.
+    If you require a password to secure the private key, set it now:
+   </para>
+<screen>&prompt.user;ssh-keygen -p -f $HOME/.ssh/cluster</screen>
+  </step>
+  <step>
+   <para>
     Importing the &warewulf; container from the &suse; registry requires &scc; credentials.
-    Set your credentials as environment variables before you import the container:
+    Set your SCC credentials as environment variables before you import the container:
    </para>
 <screen>&prompt.user;export WAREWULF_OCI_USERNAME=<replaceable>USER@EXAMPLE.COM</replaceable>
 &prompt.user;export WAREWULF_OCI_PASSWORD=<replaceable>REGISTRATION_CODE</replaceable></screen>
@@ -142,10 +199,10 @@ hpcnode&product-ga;.&product-sp; --setdefault</screen>
   </step>
   <step>
    <para>
-    Configure the networking details for the <literal>default</literal> node profile:
+    Configure the networking details for the <literal>default</literal> profile:
    </para>
 <screen>&prompt.user;sudo wwctl profile set -y default --netname default \
---netmask &subnetmask; --gateway &subnetI;.1</screen>
+--netmask &subnetmask; --gateway &subnetI;.250</screen>
    <para>
     To see the details of this profile, run the following command:
    </para>
@@ -158,7 +215,7 @@ hpcnode&product-ga;.&product-sp; --setdefault</screen>
    </para>
 <screen>&prompt.user;sudo wwctl node add node[01-10] \ <co xml:id="co-warewulf-deploy-node-name"/>
 --netdev eth0 -I &subnetI;.100 \ <co xml:id="co-warewulf-deploy-node-network"/>
---discoverable true <co xml:id="co-warewulf-deploy-node-discover"/></screen>
+--discoverable=true <co xml:id="co-warewulf-deploy-node-discover"/></screen>
    <calloutlist>
     <callout arearefs="co-warewulf-deploy-node-name">
      <para>

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE sect1
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<sect1 xml:id="sec-warewulf-deploy-nodes" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Deploying compute nodes with &warewulf;</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+ <para>
+  <remark>Add info on &warewulf;, profiles, overlays, etc.</remark>
+ </para>
+ <para>
+  For more information, see <link xlink:href="https://warewulf.org/docs/"/>.
+ </para>
+ <procedure xml:id="pro-warewulf-deploy-nodes">
+  <title>Deploying compute nodes with &warewulf;</title>
+  <step>
+   <para>
+    Install &warewulf;:
+   </para>
+<screen>&prompt.user;sudo zypper install warewulf4</screen>
+  </step>
+  <step>
+   <para>
+    Configure the controller host <remark>WIP</remark>
+   </para>
+  </step>
+  <step>
+   <para>
+    Start and enable the &warewulf; service:
+   </para>
+<screen>&prompt.user;sudo systemctl enable --now warewulfd</screen>
+  </step>
+  <step>
+   <para>
+    If the dhcpd service was not used before you will have to add the interface on which the cluster network is running to the DHCP_INTERFACE in the file /etc/sysconfig/dhcpd. <remark>WIP</remark>
+   </para>
+  </step>
+  <step>
+   <para>
+    Configure the services required by &warewulf;:
+   </para>
+<screen>&prompt.user;sudo wwctl configure --all</screen>
+   <para>
+    <remark>Add description of what this does.</remark>
+   </para>
+  </step>
+  <step>
+   <para>
+    Import a compute node container from the &suse; registry:
+   </para>
+<screen>&prompt.user;sudo wwctl container import \
+docker://registry.suse.com/suse/containers/<remark>TBD</remark> \
+<remark>TBD</remark> --setdefault</screen>
+   <para>
+    The <option>--setdefault</option> argument sets this as the default container
+    in the <literal>default</literal> node profile.
+   </para>
+  </step>
+  <step>
+   <para>
+    Configure the networking details for the <literal>default</literal> node profile:
+   </para>
+<screen>&prompt.user;sudo wwctl profile set -y default --netname default \
+--netmask &subnetmask; --gateway &subnetI;.1</screen>
+   <para>
+    To see the details of this profile, run the following command:
+   </para>
+<screen>&prompt.user;sudo wwctl profile list -a</screen>
+  </step>
+  <step>
+   <para>
+    Add compute nodes to &warewulf;. For example, to add ten discoverable nodes
+    with preconfigured IP addresses, run the following command:
+   </para>
+<screen>&prompt.user;sudo wwctl node add n[01-10] \ <co xml:id="co-warewulf-deploy-node-name"/>
+--netdev eth0 -I &subnetI;.11 \ <co xml:id="co-warewulf-deploy-node-network"/>
+--discoverable=true <co xml:id="co-warewulf-deploy-node-discover"/></screen>
+   <calloutlist>
+    <callout arearefs="co-warewulf-deploy-node-name">
+     <para>
+      One or more node names. Node names must be unique. If you have node groups
+      or multiple clusters, add descriptors to the node names, for example
+      <literal>n01.cluster01</literal>.
+     </para>
+    </callout>
+    <callout arearefs="co-warewulf-deploy-node-network">
+     <para>
+      The IP address for the first node. Subsequent nodes will be given incremental
+      IP addresses.
+     </para>
+    </callout>
+    <callout arearefs="co-warewulf-deploy-node-discover">
+     <para>
+      Allows &warewulf; to assign a MAC address to the nodes when they boot for
+      the first time.
+     </para>
+    </callout>
+   </calloutlist>
+   <para>
+    To view the settings for these nodes, run the following command:
+   </para>
+<screen>&prompt.user;sudo wwctl node list -a n[01-10]</screen>
+  </step>
+  <step>
+   <para>
+    <remark>Do we need an actual step for overlays? Do you have to run <command>wwctl overlay build</command> before you boot the nodes, or is that only if you edited any overlays?</remark>
+   </para>
+   <para>
+    <remark>Is it possible to use overlays to do things like install &slurm;?</remark>
+   </para>
+  </step>
+  <step>
+   <para>
+    Boot the compute nodes via PXE.
+   </para>
+  </step>
+ </procedure>
+</sect1>

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -16,7 +16,9 @@
  <info>
   <abstract>
    <para>
-    &hpc; clusters consist of one or more sets of identical compute nodes. In large clusters, each set could contain thousands of machines. To help deploy so many compute nodes as clusters scale up, the &hpcm; provides the deployment tool <emphasis>&warewulf;</emphasis>.
+    &hpc; clusters consist of one or more sets of identical compute nodes. In large clusters,
+    each set could contain thousands of machines. To help deploy so many compute nodes as
+    clusters scale up, the &hpcm; provides the deployment tool <emphasis>&warewulf;</emphasis>.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -357,16 +359,116 @@ hpcnode&product-ga;.&product-sp; --setdefault</screen>
   </sect2>
   <sect2 xml:id="sec-warewulf-storage">
    <title>Configuring local node storage</title>
-   <para></para>
-   <important role="compact">
-     <para>
-       I attempted to test this procedure but got <literal>No provider found</literal> for
-       <package>ignition</package>.
-     </para>
-     <para>
-       Searched SCC; ignition is only in Package Hub for 15 SP4 and earlier.
-     </para>
-   </important>
+   <para>
+    Nodes provisioned by &warewulf; are ephemeral, so local disk storage is not required.
+    However, local storage can still be useful, for example, as scratch storage for
+    computational tasks.
+   </para>
+   <para>
+    &warewulf; can set up and manage local storage for compute nodes via the disk provisioning
+    tool &ignition;. Before booting the compute nodes, you must install &ignition; in the
+    &warewulf; container and add the disk details to either a node profile or individual nodes.
+    A node or profile can have multiple disks.
+   </para>
+   <para>
+    Use the following procedure to install &ignition; in the &warewulf; container:
+   </para>
+   <procedure xml:id="pro-warewulf-storage-prep-container">
+     <title>Preparing a &warewulf; container for local storage</title>
+     <step>
+       <para>
+         Open a shell in the &warewulf; container:
+       </para>
+<screen>&prompt.user;sudo wwctl container shell hpcnode&productnumbershort;</screen>
+     </step>
+     <step>
+       <para>
+         Install the <package>ignition</package> and <package>gptfdisk</package> packages:
+       </para>
+<screen>&prompt.wwcon;zypper install ignition gptfdisk</screen>
+     </step>
+     <step>
+       <para>
+        Exit the container's shell:
+       </para>
+<screen>&prompt.wwcon;exit</screen>
+       <para>
+        &warewulf; automatically rebuilds the container.
+       </para>
+     </step>
+     <step>
+       <para>
+         We recommend rebuilding the container again manually to make sure the changes are applied:
+       </para>
+<screen>&prompt.user;sudo wwctl container build hpcnode&productnumbershort;</screen>
+     </step>
+   </procedure>
+   <para>
+    The following examples demonstrate how to add a disk to a compute node's configuration file.
+    To set up the disk, &ignition; requires details about the physical storage device,
+    the partitions on the disk, and the file system to use.
+   </para>
+   <para>
+    To add disks to a profile instead of an individual node, use the same commands but
+    replace <command>wwctl node set <replaceable>NODENAME</replaceable></command> with
+    <command>wwctl profile set <replaceable>PROFILENAME</replaceable></command>.
+   </para>
+   <example xml:id="ex-warewulf-storage-add-scratch-partition">
+     <title>Adding disk configuration to a node: scratch partition</title>
+<screen>&prompt.user;sudo wwctl node set node01 \
+--diskname /dev/vda<co xml:id="co-warewulf-storage-diskname"/> --diskwipe \
+--partname scratch<co xml:id="co-warewulf-storage-partname"/> --partcreate \
+--fsname scratch<co xml:id="co-warewulf-storage-fsname"/> --fsformat btrfs<co xml:id="co-warewulf-storage-fsformat"/> --fspath /scratch<co xml:id="co-warewulf-storage-fspath"/> --fswipe</screen>
+    <para>
+      This is the last partition, so does not require a partition size or number;
+      it will be extended to the maximum possible size.
+    </para>
+   </example>
+
+   <example xml:id="ex-warewulf-storage-add-swap-partition">
+     <title>Adding disk configuration to a node: swap partition</title>
+<screen>&prompt.user;sudo wwctl node set node01 \
+--diskname /dev/vda<xref linkend="co-warewulf-storage-diskname"/> \
+--partname swap<xref linkend="co-warewulf-storage-partname"/> --partsize=1024 --partnumber 1 \
+--fsname swap<xref linkend="co-warewulf-storage-fsname"/> --fsformat swap<xref linkend="co-warewulf-storage-fsformat"/> --fspath swap<xref linkend="co-warewulf-storage-fspath"/></screen>
+    <para>
+     Set a <literal>partsize</literal> and <literal>partnumber</literal> for all partitions
+     except the last one (<literal>scratch</literal>).
+    </para>
+   </example>
+   <calloutlist>
+     <callout arearefs="co-warewulf-storage-diskname">
+       <para>
+         The path to the physical storage device.
+       </para>
+    </callout>
+    <callout arearefs="co-warewulf-storage-partname">
+       <para>
+         The name of the partition. This is used as the partition label, for example, in
+        <filename>/dev/disk/by-partlabel/<replaceable>PARTNAME</replaceable></filename>.
+       </para>
+     </callout>
+     <callout arearefs="co-warewulf-storage-fsname">
+       <para>
+         The path to the partition that will contain the file system, using the
+         <literal>/dev/disk/by-partlabel/</literal> format.
+       </para>
+     </callout>
+     <callout arearefs="co-warewulf-storage-fsformat">
+       <para>
+         The type of file system to use. &ignition; fails if no type is defined.
+       </para>
+     </callout>
+     <callout arearefs="co-warewulf-storage-fspath">
+       <para>
+        The absolute path for the mount point. This is mandatory if you intend to mount
+        the file system.
+       </para>
+     </callout>
+   </calloutlist>
+   <para>
+    For more information about the available options, run <command>wwctl node set --help</command>.
+   </para>
   </sect2>
  </sect1>
 

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -2,292 +2,327 @@
 <?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
  type="text/xml"
  title="Profiling step"?>
-<!DOCTYPE sect1
+<!DOCTYPE chapter
 [
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
 
-<sect1 xml:id="sec-warewulf-deploy-nodes" xml:lang="en"
+<chapter xml:id="cha-warewulf-deploy-nodes" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Deploying compute nodes with &warewulf;</title>
+ <title>Deploying compute nodes</title>
  <info>
+  <abstract>
+   <para>
+    &hpc; clusters consist of one or more sets of identical compute nodes. In large clusters, each set could contain thousands of machines. To help deploy so many compute nodes as clusters scale up, the &hpcm; provides the deployment tool <emphasis>&warewulf;</emphasis>.
+   </para>
+  </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
 
- <para>
-  &warewulf; is a deployment system for compute nodes in &hpc; clusters. Compute nodes
-  are booted and deployed over the network with a kernel and node image provided by &warewulf;.
-  To generate the node image, &warewulf; uses a <emphasis>&warewulf; container</emphasis>,
-  which is a base operating system container with a kernel and an <literal>init</literal>
-  implementation installed. &warewulf; configures images for the individual compute nodes using
-  <emphasis>node profiles</emphasis> and <emphasis>&warewulf; overlays</emphasis>.
- </para>
- <para>
-  <emphasis>Node profiles</emphasis> are used to apply the same configuration
-  to multiple nodes. Node profiles can include settings such as the container
-  to use, overlays to apply, and IPMI details. New nodes automatically use the
-  <literal>default</literal> node profile. You can also create additional node profiles,
-  for example, if two groups of nodes require different containers.
- </para>
- <para>
-  <emphasis>&warewulf; overlays</emphasis> are compiled for each individual compute node:
- </para>
- <itemizedlist>
-   <listitem>
-     <para>
-       System (or <literal>wwinit</literal>) overlays are applied to nodes at boot time
-       by the <literal>wwinit</literal> process, before &systemd; starts. These overlays
-       are required to start the compute nodes, and contain basic node-specific configuration
-       to start the first network interface. System overlays are not updated during runtime.
-     </para>
-   </listitem>
-   <listitem>
-     <para>
-       Runtime (or generic) overlays are updated periodically at runtime by the
-       <literal>wwclient</literal> service. The default is once per minute. These overlays
-       are used to apply configuration changes to the nodes.
-     </para>
-   </listitem>
-   <listitem>
-     <para>
-       The Host overlay is used for configuration that applies to the &warewulf; server
-       itself, such as adding entries to <filename>/etc/hosts</filename> or setting up the
-       DHCP service and NFS exports.
-     </para>
-   </listitem>
- </itemizedlist>
- <para>
-  System and runtime overlays can be overlayed on top of each other. For example, instead of
-  altering a configuration setting in an overlay, you can override it with a new overlay.
-  You can set a list of system and runtime overlays to apply to individual nodes, or to
-  multiple nodes via profiles.
- </para>
+ <sect1 xml:id="sec-about-warewulf">
+  <title>About &warewulf;</title>
+  <para>
+    &warewulf; is a deployment system for compute nodes in &hpc; clusters. Compute nodes
+    are booted and deployed over the network with a kernel and node image provided by &warewulf;.
+    To generate the node image, &warewulf; uses a <emphasis>&warewulf; container</emphasis>,
+    which is a base operating system container with a kernel and an <literal>init</literal>
+    implementation installed. &warewulf; configures images for the individual compute nodes using
+    <emphasis>node profiles</emphasis> and <emphasis>&warewulf; overlays</emphasis>.
+  </para>
+  <para>
+    <emphasis>Node profiles</emphasis> are used to apply the same configuration
+    to multiple nodes. Node profiles can include settings such as the container
+    to use, overlays to apply, and IPMI details. New nodes automatically use the
+    <literal>default</literal> node profile. You can also create additional node profiles,
+    for example, if two groups of nodes require different containers.
+  </para>
+  <para>
+    <emphasis>&warewulf; overlays</emphasis> are compiled for each individual compute node:
+  </para>
+  <itemizedlist>
+    <listitem>
+      <para>
+        System (or <literal>wwinit</literal>) overlays are applied to nodes at boot time
+        by the <literal>wwinit</literal> process, before &systemd; starts. These overlays
+        are required to start the compute nodes, and contain basic node-specific configuration
+        to start the first network interface. System overlays are not updated during runtime.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Runtime (or generic) overlays are updated periodically at runtime by the
+        <literal>wwclient</literal> service. The default is once per minute. These overlays
+        are used to apply configuration changes to the nodes.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        The Host overlay is used for configuration that applies to the &warewulf; server
+        itself, such as adding entries to <filename>/etc/hosts</filename> or setting up the
+        DHCP service and NFS exports.
+      </para>
+    </listitem>
+  </itemizedlist>
+  <para>
+    System and runtime overlays can be overlayed on top of each other. For example, instead of
+    altering a configuration setting in an overlay, you can override it with a new overlay.
+    You can set a list of system and runtime overlays to apply to individual nodes, or to
+    multiple nodes via profiles.
+  </para>
+ </sect1>
 
- <itemizedlist>
-  <title>Requirements</title>
-  <listitem>
-   <para>
-    The &warewulf; server has a static IP address.
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    The compute nodes are set to PXE boot.
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    The &warewulf; server is accessible from an external network, but is connected to
-    the compute nodes via an internal cluster network used for deployment. This is
-    important because &warewulf; configures DHCP and TFTP on the &warewulf; server,
-    which might conflict with DHCP on the external network.
-   </para>
-  </listitem>
- </itemizedlist>
-
- <procedure xml:id="pro-warewulf-deploy-nodes">
+ <sect1 xml:id="sec-warewulf-deploy-nodes">
   <title>Deploying compute nodes with &warewulf;</title>
-  <step>
-   <para>
-    On the &warewulf; server, install &warewulf;:
-   </para>
+  <itemizedlist>
+    <title>Requirements</title>
+    <listitem>
+    <para>
+      The &warewulf; server has a static IP address.
+    </para>
+    </listitem>
+    <listitem>
+    <para>
+      The compute nodes are set to PXE boot.
+    </para>
+    </listitem>
+    <listitem>
+    <para>
+      The &warewulf; server is accessible from an external network, but is connected to
+      the compute nodes via an internal cluster network used for deployment. This is
+      important because &warewulf; configures DHCP and TFTP on the &warewulf; server,
+      which might conflict with DHCP on the external network.
+    </para>
+    </listitem>
+  </itemizedlist>
+
+  <procedure xml:id="pro-warewulf-deploy-nodes">
+    <title>Deploying compute nodes with &warewulf;</title>
+    <step>
+    <para>
+      On the &warewulf; server, install &warewulf;:
+    </para>
 <screen>&prompt.user;sudo zypper install warewulf4</screen>
-  </step>
-  <step>
-   <para>
-    The installation creates a basic configuration for the &warewulf; server in the file
-    <filename>/etc/warewulf/warewulf.conf</filename>. Review this file to make sure
-    the details are correct. In particular, check the following settings:
-   </para>
+    </step>
+    <step>
+    <para>
+      The installation creates a basic configuration for the &warewulf; server in the file
+      <filename>/etc/warewulf/warewulf.conf</filename>. Review this file to make sure
+      the details are correct. In particular, check the following settings:
+    </para>
 <screen>ipaddr: &subnetI;.250
 netmask: &subnetmask;
 network: &subnetI;.0</screen>
-   <para>
-    <literal>ipaddr</literal> is the IP address of the &warewulf; server on the internal
-    cluster network to be used for node deployment. <literal>netmask</literal> and
-    <literal>network</literal> must match this network.
-   </para>
-   <para>
-    Additionally, check that the DHCP range is in the cluster network:
-   </para>
+    <para>
+      <literal>ipaddr</literal> is the IP address of the &warewulf; server on the internal
+      cluster network to be used for node deployment. <literal>netmask</literal> and
+      <literal>network</literal> must match this network.
+    </para>
+    <para>
+      Additionally, check that the DHCP range is in the cluster network:
+    </para>
 <screen>dhcp:
   range start: &subnetI;.21
   range end: &subnetI;.50</screen>
-  </step>
-  <step>
-   <para>
-    In the file <filename>/etc/sysconfig/dhcpd</filename>, check that
-    <option>DHCPD_INTERFACE</option> has the correct value. This must be
-    the interface on which the cluster network is running.
-   </para>
-  </step>
-  <step>
-   <para>
-    Start and enable the &warewulf; service:
-   </para>
+    </step>
+    <step>
+    <para>
+      In the file <filename>/etc/sysconfig/dhcpd</filename>, check that
+      <option>DHCPD_INTERFACE</option> has the correct value. This must be
+      the interface on which the cluster network is running.
+    </para>
+    </step>
+    <step>
+    <para>
+      Start and enable the &warewulf; service:
+    </para>
 <screen>&prompt.user;sudo systemctl enable --now warewulfd</screen>
-  </step>
-  <step>
-   <para>
-    Configure the services required by &warewulf;:
-   </para>
+    </step>
+    <step>
+    <para>
+      Configure the services required by &warewulf;:
+    </para>
 <screen>&prompt.user;sudo wwctl configure --all</screen>
-   <para>
-    This command performs the following tasks:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      Configures DHCP and enables the DHCP service.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Writes the required PXE files to the TFTP root directory and enables the TFTP service.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Updates the <filename>/etc/hosts</filename> file.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Configures an NFS server on the &warewulf; server and enables the NFS service.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Creates host keys and user keys for passwordless SSH access to the nodes.
-     </para>
-    </listitem>
-   </itemizedlist>
-  </step>
-  <step>
-   <para>
-    When the configuration is finished, log out of the &warewulf; server and back into it.
-    This creates an SSH key pair to allow passwordless login to the deployed compute nodes.
-    If you require a password to secure the private key, set it now:
-   </para>
+    <para>
+      This command performs the following tasks:
+    </para>
+    <itemizedlist>
+      <listitem>
+      <para>
+        Configures DHCP and enables the DHCP service.
+      </para>
+      </listitem>
+      <listitem>
+      <para>
+        Writes the required PXE files to the TFTP root directory and enables the TFTP service.
+      </para>
+      </listitem>
+      <listitem>
+      <para>
+        Updates the <filename>/etc/hosts</filename> file.
+      </para>
+      </listitem>
+      <listitem>
+      <para>
+        Configures an NFS server on the &warewulf; server and enables the NFS service.
+      </para>
+      </listitem>
+      <listitem>
+      <para>
+        Creates host keys and user keys for passwordless SSH access to the nodes.
+      </para>
+      </listitem>
+    </itemizedlist>
+    </step>
+    <step>
+    <para>
+      When the configuration is finished, log out of the &warewulf; server and back into it.
+      This creates an SSH key pair to allow passwordless login to the deployed compute nodes.
+      If you require a password to secure the private key, set it now:
+    </para>
 <screen>&prompt.user;ssh-keygen -p -f $HOME/.ssh/cluster</screen>
-  </step>
-  <step>
-   <para>
-    Importing the &warewulf; container from the &suse; registry requires &scc; credentials.
-    Set your SCC credentials as environment variables before you import the container:
-   </para>
+    </step>
+    <step>
+    <para>
+      Importing the &warewulf; container from the &suse; registry requires &scc; credentials.
+      Set your SCC credentials as environment variables before you import the container:
+    </para>
 <screen>&prompt.user;export WAREWULF_OCI_USERNAME=<replaceable>USER@EXAMPLE.COM</replaceable>
 &prompt.user;export WAREWULF_OCI_PASSWORD=<replaceable>REGISTRATION_CODE</replaceable></screen>
-  </step>
-  <step>
-   <para>
-    Import the &warewulf; container from the &suse; registry:
-   </para>
+    </step>
+    <step>
+    <para>
+      Import the &warewulf; container from the &suse; registry:
+    </para>
 <screen>&prompt.user;sudo wwctl container import \
 docker://registry.suse.com/suse/hpc/warewulf4-x86_64/sle-hpc-node:&product-ga;.&product-sp; \
 hpcnode&product-ga;.&product-sp; --setdefault</screen>
-   <para>
-    The <option>--setdefault</option> argument sets this as the default container
-    in the <literal>default</literal> node profile.
-   </para>
-  </step>
-  <step>
-   <para>
-    Configure the networking details for the <literal>default</literal> profile:
-   </para>
+    <para>
+      The <option>--setdefault</option> argument sets this as the default container
+      in the <literal>default</literal> node profile.
+    </para>
+    </step>
+    <step>
+    <para>
+      Configure the networking details for the <literal>default</literal> profile:
+    </para>
 <screen>&prompt.user;sudo wwctl profile set -y default --netname default \
 --netmask &subnetmask; --gateway &subnetI;.250</screen>
-   <para>
-    To see the details of this profile, run the following command:
-   </para>
+    <para>
+      To see the details of this profile, run the following command:
+    </para>
 <screen>&prompt.user;sudo wwctl profile list -a default</screen>
-  </step>
-  <step>
-   <para>
-    Add compute nodes to &warewulf;. For example, to add ten discoverable nodes
-    with preconfigured IP addresses, run the following command:
-   </para>
+    </step>
+    <step>
+    <para>
+      Add compute nodes to &warewulf;. For example, to add ten discoverable nodes
+      with preconfigured IP addresses, run the following command:
+    </para>
 <screen>&prompt.user;sudo wwctl node add node[01-10] \ <co xml:id="co-warewulf-deploy-node-name"/>
 --netdev eth0 -I &subnetI;.100 \ <co xml:id="co-warewulf-deploy-node-network"/>
 --discoverable=true <co xml:id="co-warewulf-deploy-node-discover"/></screen>
-   <calloutlist>
-    <callout arearefs="co-warewulf-deploy-node-name">
-     <para>
-      One or more node names. Node names must be unique. If you have node groups
-      or multiple clusters, add descriptors to the node names, for example
-      <literal>node01.cluster01</literal>.
-     </para>
-    </callout>
-    <callout arearefs="co-warewulf-deploy-node-network">
-     <para>
-      The IP address for the first node. Subsequent nodes are given incremental
-      IP addresses.
-     </para>
-    </callout>
-    <callout arearefs="co-warewulf-deploy-node-discover">
-     <para>
-      Allows &warewulf; to assign a MAC address to the nodes when they boot for
-      the first time.
-     </para>
-    </callout>
-   </calloutlist>
-   <para>
-    To view the settings for these nodes, run the following command:
-   </para>
+    <calloutlist>
+      <callout arearefs="co-warewulf-deploy-node-name">
+      <para>
+        One or more node names. Node names must be unique. If you have node groups
+        or multiple clusters, add descriptors to the node names, for example
+        <literal>node01.cluster01</literal>.
+      </para>
+      </callout>
+      <callout arearefs="co-warewulf-deploy-node-network">
+      <para>
+        The IP address for the first node. Subsequent nodes are given incremental
+        IP addresses.
+      </para>
+      </callout>
+      <callout arearefs="co-warewulf-deploy-node-discover">
+      <para>
+        Allows &warewulf; to assign a MAC address to the nodes when they boot for
+        the first time.
+      </para>
+      </callout>
+    </calloutlist>
+    <para>
+      To view the settings for these nodes, run the following command:
+    </para>
 <screen>&prompt.user;sudo wwctl node list -a node[01-10]</screen>
-  </step>
-  <step>
-   <para>
-    Add the nodes to the <filename>/etc/hosts</filename> file:
-   </para>
+    </step>
+    <step>
+    <para>
+      Add the nodes to the <filename>/etc/hosts</filename> file:
+    </para>
 <screen>&prompt.user;sudo wwctl configure hostfile</screen>
-  </step>
-  <step>
-   <para>
-    Rebuild the container image to make sure it is ready to use:
-   </para>
+    </step>
+    <step>
+    <para>
+      Rebuild the container image to make sure it is ready to use:
+    </para>
 <screen>&prompt.user;sudo wwctl container build hpcnode&product-ga;.&product-sp;</screen>
-  </step>
-  <step>
-   <para>
-    Build the default system and runtime overlays:
-   </para>
+    </step>
+    <step>
+    <para>
+      Build the default system and runtime overlays:
+    </para>
 <screen>&prompt.user;sudo wwctl overlay build</screen>
-   <para>
-    This command compiles overlays for all the nodes.
-   </para>
-  </step>
- </procedure>
- <para>
-   You can now boot the compute nodes with PXE. &warewulf; provides all the required information.
- </para>
- <itemizedlist>
-  <title>For more information</title>
-  <listitem>
-   <para>
-    &warewulf;: <link xlink:href="https://warewulf.org/docs/development/index.html"/>
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    Node profiles: <link xlink:href="https://warewulf.org/docs/development/contents/profiles.html"/>
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    &warewulf; overlays: <link xlink:href="https://warewulf.org/docs/development/contents/overlays.html"/>
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    The node provisioning process: <link xlink:href="https://warewulf.org/docs/development/contents/provisioning.html"/>
-   </para>
-  </listitem>
- </itemizedlist>
-</sect1>
+    <para>
+      This command compiles overlays for all the nodes.
+    </para>
+    </step>
+  </procedure>
+  <para>
+    You can now boot the compute nodes with PXE. &warewulf; provides all the required information.
+  </para>
+ </sect1>
+
+ <sect1 xml:id="sec-warewulf-advanced-tasks">
+  <title>Advanced &warewulf; tasks</title>
+  <sect2>
+   <title>Creating, modifying, and specifying profiles</title>
+   <para></para>
+  </sect2>
+  <sect2>
+   <title>Creating and specifying overlays</title>
+   <para></para>
+  </sect2>
+  <sect2>
+   <title>Using &warewulf; with Secure Boot</title>
+   <para></para>
+  </sect2>
+  <sect2>
+   <title>Configuring local node storage</title>
+   <para></para>
+  </sect2>
+ </sect1>
+
+ <sect1 xml:id="sec-warewulf-more-info">
+ <title>For more information</title>
+  <itemizedlist>
+    <listitem>
+    <para>
+      &warewulf;: <link xlink:href="https://warewulf.org/docs/development/index.html"/>
+    </para>
+    </listitem>
+    <listitem>
+    <para>
+      Node profiles: <link xlink:href="https://warewulf.org/docs/development/contents/profiles.html"/>
+    </para>
+    </listitem>
+    <listitem>
+    <para>
+      &warewulf; overlays: <link xlink:href="https://warewulf.org/docs/development/contents/overlays.html"/>
+    </para>
+    </listitem>
+    <listitem>
+    <para>
+      The node provisioning process: <link xlink:href="https://warewulf.org/docs/development/contents/provisioning.html"/>
+    </para>
+    </listitem>
+  </itemizedlist>
+ </sect1>
+
+</chapter>

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -23,12 +23,14 @@
  <para>
   &warewulf; is a node deployment system for &hpc; clusters. Compute nodes are booted
   over the network using a <emphasis>&warewulf; container</emphasis>, which is a node image
-  with a bootable kernel. &warewulf; configures DHCP and TFTP on the &warewulf; server
-  (or control node), and configures the compute nodes using <emphasis>node profiles</emphasis>
+  with a bootable kernel. &warewulf; configures DHCP and TFTP on the &warewulf; server,
+  and configures the compute nodes using <emphasis>node profiles</emphasis>
   and <emphasis>&warewulf; overlays</emphasis>.
  </para>
  <para>
-  <emphasis>Node profiles</emphasis> are used to group configurations together so that they can be applied to multiple nodes. Node profiles can include settings such as the container to use, overlays to apply, and IPMI details. New nodes automatically use the
+  <emphasis>Node profiles</emphasis> are used to group configurations together so that they
+  can be applied to multiple nodes. Node profiles can include settings such as the container
+  to use, overlays to apply, and IPMI details. New nodes automatically use the
   <literal>default</literal> node profile. You can also create additional node profiles,
   for example, if two groups of nodes require different containers.
  </para>
@@ -71,16 +73,16 @@
   </step>
   <step>
    <para>
-    Start and enable the &warewulf; service:
+    In the file <filename>/etc/sysconfig/dhcpd</filename>, check that
+    <option>DHCPD_INTERFACE</option> has the correct value. This must be
+    the interface on which the cluster network is running.
    </para>
-<screen>&prompt.user;sudo systemctl enable --now warewulfd</screen>
   </step>
   <step>
    <para>
-    If DHCP is not already in use, add the interface on which
-    the cluster network is running to <option>DHCP_INTERFACE</option> in the
-    file <filename>/etc/sysconfig/dhcpd</filename>.
+    Start and enable the &warewulf; service:
    </para>
+<screen>&prompt.user;sudo systemctl enable --now warewulfd</screen>
   </step>
   <step>
    <para>
@@ -119,10 +121,10 @@
    </itemizedlist>
   </step>
   <step>
-    <para>
-      Importing the &warewulf; container from the &suse; registry requires &scc; credentials.
-      Set your credentials as environment variables before you import the container:
-    </para>
+   <para>
+    Importing the &warewulf; container from the &suse; registry requires &scc; credentials.
+    Set your credentials as environment variables before you import the container:
+   </para>
 <screen>&prompt.user;export WAREWULF_OCI_USERNAME=<replaceable>USER@EXAMPLE.COM</replaceable>
 &prompt.user;export WAREWULF_OCI_PASSWORD=<replaceable>REGISTRATION_CODE</replaceable></screen>
   </step>
@@ -147,22 +149,22 @@ hpcnode&product-ga;.&product-sp; --setdefault</screen>
    <para>
     To see the details of this profile, run the following command:
    </para>
-<screen>&prompt.user;sudo wwctl profile list -a</screen>
+<screen>&prompt.user;sudo wwctl profile list -a default</screen>
   </step>
   <step>
    <para>
     Add compute nodes to &warewulf;. For example, to add ten discoverable nodes
     with preconfigured IP addresses, run the following command:
    </para>
-<screen>&prompt.user;sudo wwctl node add n[01-10] \ <co xml:id="co-warewulf-deploy-node-name"/>
+<screen>&prompt.user;sudo wwctl node add node[01-10] \ <co xml:id="co-warewulf-deploy-node-name"/>
 --netdev eth0 -I &subnetI;.100 \ <co xml:id="co-warewulf-deploy-node-network"/>
---discoverable=true <co xml:id="co-warewulf-deploy-node-discover"/></screen>
+--discoverable true <co xml:id="co-warewulf-deploy-node-discover"/></screen>
    <calloutlist>
     <callout arearefs="co-warewulf-deploy-node-name">
      <para>
       One or more node names. Node names must be unique. If you have node groups
       or multiple clusters, add descriptors to the node names, for example
-      <literal>n01.cluster01</literal>.
+      <literal>node01.cluster01</literal>.
      </para>
     </callout>
     <callout arearefs="co-warewulf-deploy-node-network">
@@ -181,7 +183,19 @@ hpcnode&product-ga;.&product-sp; --setdefault</screen>
    <para>
     To view the settings for these nodes, run the following command:
    </para>
-<screen>&prompt.user;sudo wwctl node list -a n[01-10]</screen>
+<screen>&prompt.user;sudo wwctl node list -a node[01-10]</screen>
+  </step>
+  <step>
+   <para>
+    Add the nodes to the <filename>/etc/hosts</filename> file:
+   </para>
+<screen>&prompt.user;sudo wwctl configure hostfile</screen>
+  </step>
+  <step>
+   <para>
+    Rebuild the container image to make sure it is ready to use:
+   </para>
+<screen>&prompt.user;sudo wwctl container build hpcnode&product-ga;.&product-sp;</screen>
   </step>
   <step>
    <para>
@@ -189,15 +203,13 @@ hpcnode&product-ga;.&product-sp; --setdefault</screen>
    </para>
 <screen>&prompt.user;sudo wwctl overlay build</screen>
    <para>
-    This command compiles overlays for all the nodes added in the previous step.
-   </para>
-  </step>
-  <step>
-   <para>
-    Boot the compute nodes with PXE. &warewulf; provides all the required information.
+    This command compiles overlays for all the nodes.
    </para>
   </step>
  </procedure>
+ <para>
+   You can now boot the compute nodes with PXE. &warewulf; provides all the required information.
+ </para>
  <itemizedlist>
   <title>For more information</title>
   <listitem>

--- a/xml/warewulf.xml
+++ b/xml/warewulf.xml
@@ -21,14 +21,14 @@
  </info>
 
  <para>
-  &warewulf; is a node deployment system for &hpc; clusters. The compute nodes are booted
-  over the network using PXE. &warewulf; configures DHCP and TFTP on the &warewulf; server
+  &warewulf; is a node deployment system for &hpc; clusters. Compute nodes are booted
+  over the network using a <emphasis>&warewulf; container</emphasis>, which is a node image
+  with a bootable kernel. &warewulf; configures DHCP and TFTP on the &warewulf; server
   (or control node), and configures the compute nodes using <emphasis>node profiles</emphasis>
   and <emphasis>&warewulf; overlays</emphasis>.
  </para>
  <para>
-  <emphasis>Node profiles</emphasis> group shared node configurations together, such as
-  the container or kernel, overlays, and IPMI settings. New nodes automatically use the
+  <emphasis>Node profiles</emphasis> are used to group configurations together so that they can be applied to multiple nodes. Node profiles can include settings such as the container to use, overlays to apply, and IPMI details. New nodes automatically use the
   <literal>default</literal> node profile. You can also create additional node profiles,
   for example, if two groups of nodes require different containers.
  </para>
@@ -36,7 +36,7 @@
   <emphasis>&warewulf; overlays</emphasis> are compiled for each individual compute node.
   System overlays (or <literal>wwinit</literal> overlays) are applied during boot and are
   used for configuration that is node-specific, such as networking and services. Runtime
-  overlays are applied periodically while the node is running, and are used for configuration
+  overlays are applied periodically while the node is running and are used for configuration
   that changes, such as users and groups.
  </para>
 
@@ -77,7 +77,7 @@
   </step>
   <step>
    <para>
-    If DHCP is not already in use on this node, add the interface on which
+    If DHCP is not already in use, add the interface on which
     the cluster network is running to <option>DHCP_INTERFACE</option> in the
     file <filename>/etc/sysconfig/dhcpd</filename>.
    </para>
@@ -159,7 +159,7 @@ docker://registry.suse.com/suse/containers/<remark>TBD</remark> \
     </callout>
     <callout arearefs="co-warewulf-deploy-node-network">
      <para>
-      The IP address for the first node. Subsequent nodes will be given incremental
+      The IP address for the first node. Subsequent nodes are given incremental
       IP addresses.
      </para>
     </callout>
@@ -177,17 +177,16 @@ docker://registry.suse.com/suse/containers/<remark>TBD</remark> \
   </step>
   <step>
    <para>
-    Build the default system and runtime overlays for each node:
+    Build the default system and runtime overlays:
    </para>
 <screen>&prompt.user;sudo wwctl overlay build</screen>
    <para>
-    <remark>Are there any HPC-specific things that we should direct people to
-     add to an overlay/create an overlay for?</remark>
+    This command compiles overlays for all the nodes added in the previous step.
    </para>
   </step>
   <step>
    <para>
-    Boot the compute nodes with PXE. &warewulf; provides all of the required information.
+    Boot the compute nodes with PXE. &warewulf; provides all the required information.
    </para>
   </step>
  </procedure>


### PR DESCRIPTION
### Description

I've added a chapter for Warewulf. 
It now includes separate sections because the description got pretty long, plus there is now a section for advanced tasks. I included secure boot and local node storage, but not profiles and overlays because that would basically be reference material, and the warewulf.org docs on those are pretty decent already so I'd just be copying them. I've included links to those sections of the Warewulf docs in the For More Information section, and imo that's enough in this case.

Here's a PDF:
[cha-warewulf-deploy-nodes_en.pdf](https://github.com/SUSE/doc-hpc/files/15399735/cha-warewulf-deploy-nodes_en.pdf) **(updated May 22)**


### Are there any relevant issues/feature requests?

* jsc#PED-3011
* jsc#PED-8122

### Which product versions do the changes apply to?

- [x] SLE HPC 15 next *(current `main`, no backport necessary)*
- [x] SLE HPC 15 SP5
- [ ] SLE HPC 15 SP4
- [ ] SLE HPC 15 SP3

**Note:** Remove local node storage when cherry-picking to 15 SP5, as there are currently no plans to backport Ignition. 

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
