### PR TITLE
Fix command typo and package name

### DIFF
--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -558,7 +558,7 @@
    <itemizedlist>
     <listitem>
      <para>
-      <package>hdf5-examples</package>
+      <package>hdf5-hpc-examples</package>
      </para>
     </listitem>
     <listitem>

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -546,7 +546,7 @@
     When an MPI flavor is loaded, you can load the MPI version of this module
     by running the following command:
    </para>
-<screen>&prompt.user;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> phpdf5</screen>
+<screen>&prompt.user;module load <replaceable>TOOLCHAIN</replaceable> <replaceable>MPI_FLAVOR</replaceable> phdf5</screen>
    <para>
     For information about the toolchain to load, see <xref
     linkend="sec-compiler"/>. For information about available MPI flavors, see


### PR DESCRIPTION
### Description

Changed `phpdf5` to `phdf5` and `hdf5-examples` to `hdf5-hpc-examples`.

### Are there any relevant issues/feature requests?

* bsc#1216460
* jsc#DOCTEAM-1135

### Which product versions do the changes apply to?

- [x] SLE HPC 15 next *(current `main`, no backport necessary)*
- [x] SLE HPC 15 SP5
- [x] SLE HPC 15 SP4
- [x] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
