### PR TITLE
zypper up is not recommended

### DIFF
--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -892,8 +892,8 @@ Description="subgroup" Organization=bavaria</screen>
      <para>
        On systems running &slurm;, updating packages with <command>zypper up</command>
        is not recommended. <command>zypper up</command> attempts to update all installed
-       packages to the latest version, so might install new versions of &slurm; outside of
-       planned &slurm; upgrades.
+       packages to the latest version, so might install a new major version of &slurm;
+       outside of planned &slurm; upgrades.
      </para>
      <para>
        Use <command>zypper patch</command> instead, which only updates packages to the

--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -887,6 +887,19 @@ Description="subgroup" Organization=bavaria</screen>
     upgrades are not installed unintentionally and gives you the opportunity
     to plan version upgrades beforehand.
    </para>
+   <important>
+     <title><command>zypper up</command> is not recommended</title>
+     <para>
+       On systems running &slurm;, updating packages with <command>zypper up</command>
+       is not recommended. <command>zypper up</command> attempts to update all installed
+       packages to the latest version, so might install new versions of &slurm; outside of
+       planned &slurm; upgrades.
+     </para>
+     <para>
+       Use <command>zypper patch</command> instead, which only updates packages to the
+       latest bug fix version.
+     </para>
+   </important>
   <sect2 xml:id="sec-slurm-upgrade-workflow">
    <title>&slurm; upgrade workflow</title>
    <para>


### PR DESCRIPTION
### Description

Recommend using `zypper patch` instead of `zypper up` for systems running Slurm.

### Are there any relevant issues/feature requests?

* bsc#1216869
* jsc#DOCTEAM-1215

### Which product versions do the changes apply to?

- [x] SLE HPC 15 next *(current `main`, no backport necessary)*
- [x] SLE HPC 15 SP5
- [x] SLE HPC 15 SP4
- [x] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
