### PR TITLE
Switch to HPC module name

### DIFF
--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -20,10 +20,10 @@
     instances of the same libraries might exist, differing in version, build
     configuration, compiler, and MPI implementation. To manage these
     dependencies, you can use an environment module system. Most &hpca;
-    libraries provided with the &hpca; Module for &sles; are built with support for environment
+    libraries provided with the &hpca; module for &sles; are built with support for environment
     modules. This chapter describes the environment module system
     <emphasis>Lmod</emphasis>, and a set of &hpca;
-    compute libraries shipped with the &hpca; Module.
+    compute libraries shipped with the &hpca; module.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -152,7 +152,7 @@
   <title>GNU Compiler Toolchain Collection for &hpca;</title>
 
   <para>
-   In the &hpca; Module for &sles;, the GNU compiler collection version 7 is provided as the base
+   In the &hpca; module for &sles;, the GNU compiler collection version 7 is provided as the base
    compiler toolchain. The <package>gnu-compilers-hpc</package> package provides the
    environment module for the base version of the GNU compiler suite. This
    package must be installed when using any of the &hpca; libraries enabled for
@@ -196,7 +196,7 @@
   <sect2 xml:id="sec-compiler-later-versions">
    <title>Later versions</title>
    <para>
-    The Development Tools Module might provide later versions of the GNU compiler
+    The Development Tools module might provide later versions of the GNU compiler
     suite. To determine the available compiler suites, run the following command:
    </para>
 <screen>&prompt.user;zypper search '*-compilers-hpc'</screen>
@@ -276,13 +276,13 @@
   </para>
 
   <para>
-   The GNU compiler collection version 7 as provided with the &hpca; Module
+   The GNU compiler collection version 7 as provided with the &hpca; module
    and the MPI flavors Open MPI v.3, Open MPI v.4, MPICH, and MVAPICH2 are
    currently supported.
   </para>
 
   <para>
-   The Development Tools Module might provide later versions of the GNU compiler
+   The Development Tools module might provide later versions of the GNU compiler
    suite. To view available compilers, run the following command:
   </para>
 
@@ -776,7 +776,7 @@
   <title>Profiling and benchmarking libraries and tools</title>
 
   <para>
-   The &hpca; Module for &sles; provides tools for profiling MPI applications and benchmarking
+   The &hpca; module for &sles; provides tools for profiling MPI applications and benchmarking
    MPI performance.
   </para>
 

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -20,10 +20,10 @@
     instances of the same libraries might exist, differing in version, build
     configuration, compiler, and MPI implementation. To manage these
     dependencies, you can use an environment module system. Most &hpca;
-    libraries provided with &slehpc; are built with support for environment
+    libraries provided with the &hpca; Module for &sles; are built with support for environment
     modules. This chapter describes the environment module system
     <emphasis>Lmod</emphasis>, and a set of &hpca;
-    compute libraries shipped with &slehpca;.
+    compute libraries shipped with the &hpca; Module.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -152,7 +152,7 @@
   <title>GNU Compiler Toolchain Collection for &hpca;</title>
 
   <para>
-   In &slehpc;, the GNU compiler collection version 7 is provided as the base
+   In the &hpca; Module for &sles;, the GNU compiler collection version 7 is provided as the base
    compiler toolchain. The <package>gnu-compilers-hpc</package> package provides the
    environment module for the base version of the GNU compiler suite. This
    package must be installed when using any of the &hpca; libraries enabled for
@@ -276,7 +276,7 @@
   </para>
 
   <para>
-   The GNU compiler collection version 7 as provided with &slehpca;
+   The GNU compiler collection version 7 as provided with the &hpca; Module
    and the MPI flavors Open MPI v.3, Open MPI v.4, MPICH, and MVAPICH2 are
    currently supported.
   </para>
@@ -776,7 +776,7 @@
   <title>Profiling and benchmarking libraries and tools</title>
 
   <para>
-   &slehpc; provides tools for profiling MPI applications and benchmarking
+   The &hpca; Module for &sles; provides tools for profiling MPI applications and benchmarking
    MPI performance.
   </para>
 

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -16,7 +16,7 @@
  <info>
   <abstract>
    <para>
-    &productname; comes with preconfigured system roles for &hpca;. These
+    The &hpca; Module for &sles; comes with preconfigured system roles. These
     roles provide a set of preselected packages typical for the specific role,
     and an installation workflow that configures the system to make
     the best use of system resources based on a typical use case for the role.
@@ -29,7 +29,7 @@
  </info>
 
   <sect1 xml:id="sec2-installation-systemrole">
-   <title>System roles for &productname; &productnumber;</title>
+   <title>System roles for &sles; &hpca; Module &productnumber;</title>
    <para>
     You can choose specific roles for the system based on modules selected
     during the installation process. When the &hpca; Module is enabled,
@@ -159,44 +159,16 @@
     cluster. For more information, see <xref linkend="sec-remote-munge"/>.
    </para>
    <para>
-    The system roles are only available for new installations of &productname;.
+    The system roles are only available for new installations of the &hpca; Module for &sles;.
    </para>
   </sect1>
   <sect1 xml:id="sec2-upgrade">
-   <title>Upgrading to &productname; &productnumber;</title>
+   <title>Upgrading to &sles; &hpca; Module &productnumber;</title>
    <para>
-    <!--
-        #if <= 15SP2
-    You can upgrade to &productname; &productnumber; from &slsa; 12 SP4 or SP5
-    as well as &slehpca; &prev-version; or &slehpca; 15. When upgrading from
-    &slsa; 12 SP4/SP5, the upgrade will only be performed if the HPC
-    module has been registered prior to upgrading.
-
+    In version &productnumber;, &slehpc; (&slehpca;) was removed as a separate product, and is now available as the &hpca; Module for &sles; (&slsa;).
    </para>
    <para>
-    To upgrade from &slsa; 12 to &slehpca; 15, make sure to deregister the
-    HPC module prior to upgrading. To do so, open a root shell and
-    execute:
-   </para>
-   <screen>SUSEConnect -d -p sle-module-hpc/12/<replaceable>ARCH</replaceable></screen>
-   <para>
-    Replace <replaceable>ARCH</replaceable> with the architecture used
-    (<literal>x86_64</literal>, <literal>aarch64</literal>).
-   </para>
-   <para>
-    When migrating to &productname; &productnumber;, all modules not supported by
-    the migration target need to be deregistered. This can be done by
-    executing:
-   </para>
-   <screen>SUSEConnect -d -p sle-module-<replaceable>MODULE_NAME</replaceable>/12/<replaceable>ARCH</replaceable></screen>
-   <para>
-    Replace <replaceable>MODULE_NAME</replaceable> by the name of the module
-    and <replaceable>ARCH</replaceable> with the architecture used
-    (<literal>x86_64</literal>, <literal>aarch64</literal>).
-    #else
-    -->
-    You can upgrade to &slehpca; &productnumber; from &slehpca; &prev-version;.
- <!-- #endif -->
+     You can upgrade from &slehpca; &prev-version; to &slsa; &productnumber; plus the &hpca; Module.
    </para>
   </sect1>
 </chapter>

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -16,7 +16,7 @@
  <info>
   <abstract>
    <para>
-    The &hpca; Module for &sles; comes with preconfigured system roles. These
+    The &hpca; module for &sles; comes with preconfigured system roles. These
     roles provide a set of preselected packages typical for the specific role,
     and an installation workflow that configures the system to make
     the best use of system resources based on a typical use case for the role.
@@ -29,10 +29,10 @@
  </info>
 
   <sect1 xml:id="sec2-installation-systemrole">
-   <title>System roles for &sles; &hpca; Module &productnumber;</title>
+   <title>System roles for &sles; &hpca; module &productnumber;</title>
    <para>
     You can choose specific roles for the system based on modules selected
-    during the installation process. When the &hpca; Module is enabled,
+    during the installation process. When the &hpca; module is enabled,
     the following roles are available:
    </para>
    <variablelist>
@@ -159,16 +159,16 @@
     cluster. For more information, see <xref linkend="sec-remote-munge"/>.
    </para>
    <para>
-    The system roles are only available for new installations of the &hpca; Module for &sles;.
+    The system roles are only available for new installations of the &hpca; module for &sles;.
    </para>
   </sect1>
   <sect1 xml:id="sec2-upgrade">
-   <title>Upgrading to &sles; &hpca; Module &productnumber;</title>
+   <title>Upgrading to &sles; &hpca; module &productnumber;</title>
    <para>
-    In version &productnumber;, &slehpc; (&slehpca;) was removed as a separate product, and is now available as the &hpca; Module for &sles; (&slsa;).
+    In version 15 SP6, &slehpc; (&slehpca;) was removed as a separate product, and is now available as the &hpca; module for &sles; (&slsa;).
    </para>
    <para>
-     You can upgrade from &slehpca; &prev-version; to &slsa; &productnumber; plus the &hpca; Module.
+     You can upgrade from &slehpca; &prev-version; to &slsa; &productnumber; plus the &hpca; module.
    </para>
   </sect1>
 </chapter>

--- a/xml/introduction.xml
+++ b/xml/introduction.xml
@@ -16,7 +16,7 @@
  <info>
   <abstract>
    <para>
-    The &hpca; Module for &sles; is a highly scalable, high-performance parallel computing platform
+    The &hpca; module for &sles; is a highly scalable, high-performance parallel computing platform
     for modeling, simulation, and advanced analytics workloads.
    </para>
   </abstract>
@@ -24,7 +24,7 @@
  <sect1 xml:id="sec-intro-provides">
   <title>Components provided</title>
   <para>
-   The &hpca; Module for &sles; &productnumber; provides tools and libraries related to &hpc;.
+   The &hpca; module for &sles; &productnumber; provides tools and libraries related to &hpc;.
    This includes:
   </para>
   <itemizedlist>
@@ -100,14 +100,14 @@
  <sect1 xml:id="sec-introduction-hw">
   <title>Hardware platform support</title>
   <para>
-   The &hpca; Module is available for &sles; &productnumber; on the
+   The &hpca; module is available for &sles; &productnumber; on the
    Intel 64/AMD64 (x86-64) and AArch64 platforms.
   </para>
  </sect1>
  <sect1 xml:id="sec-introduction-life">
   <title>Support and lifecycle</title>
   <para>
-   The &hpca; Module is supported throughout the lifecycle of
+   The &hpca; module is supported throughout the lifecycle of
    &sles; &productnumber;, including the two lifecycle extensions, <emphasis>Extended Service
    Overlap Support</emphasis> (ESPOS) and <emphasis>Long Term Support
    Service</emphasis> (LTSS). Any released

--- a/xml/introduction.xml
+++ b/xml/introduction.xml
@@ -16,7 +16,7 @@
  <info>
   <abstract>
    <para>
-    &productname; is a highly scalable, high-performance parallel computing platform
+    The &hpca; Module for &sles; is a highly scalable, high-performance parallel computing platform
     for modeling, simulation, and advanced analytics workloads.
    </para>
   </abstract>
@@ -24,7 +24,7 @@
  <sect1 xml:id="sec-intro-provides">
   <title>Components provided</title>
   <para>
-   &productname; &productnumber; provides tools and libraries related to &hpc;.
+   The &hpca; Module for &sles; &productnumber; provides tools and libraries related to &hpc;.
    This includes:
   </para>
   <itemizedlist>
@@ -100,17 +100,17 @@
  <sect1 xml:id="sec-introduction-hw">
   <title>Hardware platform support</title>
   <para>
-   &productname; &productnumber; is available for the
+   The &hpca; Module is available for &sles; &productnumber; on the
    Intel 64/AMD64 (x86-64) and AArch64 platforms.
   </para>
  </sect1>
  <sect1 xml:id="sec-introduction-life">
   <title>Support and lifecycle</title>
   <para>
-   &productname; &productnumber; is supported throughout the lifecycle of
-   &sle; &productnumber;. Two lifecycle extensions, <emphasis>Extended Service
+   The &hpca; Module is supported throughout the lifecycle of
+   &sles; &productnumber;, including the two lifecycle extensions, <emphasis>Extended Service
    Overlap Support</emphasis> (ESPOS) and <emphasis>Long Term Support
-   Service</emphasis> (LTSS), are also available for this product. Any released
+   Service</emphasis> (LTSS). Any released
    package is fully maintained and supported until the availability of the next
    release.
   </para>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -15,7 +15,7 @@
 <!ENTITY product-sp    "6">
 
 <!ENTITY prev-version     "&product-ga; SP&prev-sp;">
-<!ENTITY prev-sp "4">
+<!ENTITY prev-sp "5">
 
 <!-- PROJECT REPOSITORY URL -->
 <!ENTITY repo-url "https://github.com/SUSE/doc-hpc">

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -132,7 +132,7 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
    <command>zypper in pdsh</command>.
   </para>
   <para>
-   The &hpca; Module for &sles; supports the back-ends <literal>ssh</literal>,
+   The &hpca; module for &sles; supports the back-ends <literal>ssh</literal>,
    <literal>&mrsh;</literal>, and <literal>exec</literal>. The
    <literal>ssh</literal> back-end is the default. Non-default login methods
    can be used by setting the <literal>PDSH_RCMD_TYPE</literal>

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -132,8 +132,8 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
    <command>zypper in pdsh</command>.
   </para>
   <para>
-   In &slehpc;, the back-ends <literal>ssh</literal>,
-   <literal>&mrsh;</literal>, and <literal>exec</literal> are supported. The
+   The &hpca; Module for &sles; supports the back-ends <literal>ssh</literal>,
+   <literal>&mrsh;</literal>, and <literal>exec</literal>. The
    <literal>ssh</literal> back-end is the default. Non-default login methods
    can be used by setting the <literal>PDSH_RCMD_TYPE</literal>
    environment variable, or by using the <literal>-R</literal> command


### PR DESCRIPTION
### Description

This isn't a perfect replacement; I haven't changed the `productname` or `productnameshort` entities as we're still discussing what to do at the title level.

### Are there any relevant issues/feature requests?

* jsc#PED-7683

### Which product versions do the changes apply to?

- [x] SLE HPC 15 next *(current `main`, no backport necessary)*
- [ ] SLE HPC 15 SP5
- [ ] SLE HPC 15 SP4
- [ ] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
