### PR TITLE
Change guide name

### DIFF
--- a/xml/MAIN.hpc-guide.xml
+++ b/xml/MAIN.hpc-guide.xml
@@ -14,7 +14,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
 
  <info>
-  <title>Administration Guide</title>
+  <title>High Performance Computing Guide</title>
   <productname>&productname;</productname>
   <productname role="abbrev">&productnameshort;</productname>
   <productnumber>&productnumber;</productnumber>
@@ -22,7 +22,7 @@
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>
-    This guide covers system administration tasks such as remote administration,
+    This guide covers &hpca; system administration tasks such as remote administration,
     workload management, and monitoring.
    </para>
   </abstract>

--- a/xml/MAIN.hpc-guide.xml
+++ b/xml/MAIN.hpc-guide.xml
@@ -14,7 +14,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
 
  <info>
-  <title>High Performance Computing Guide</title>
+  <title>&hpc; Guide</title>
   <productname>&productname;</productname>
   <productname role="abbrev">&productnameshort;</productname>
   <productnumber>&productnumber;</productnumber>

--- a/xml/MAIN.hpc-guide.xml
+++ b/xml/MAIN.hpc-guide.xml
@@ -22,8 +22,10 @@
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>
-    This guide covers &hpca; system administration tasks such as remote administration,
-    workload management, and monitoring.
+    The &hpcm; for &sles; is a highly scalable, high-performance, open-source parallel computing
+    platform for modeling, simulation and advanced analytics workloads. It provides tools and
+    libraries related to &hpc;, including a workload manager, remote and parallel shells,
+    monitoring and measuring tools, and libraries to accomplish &hpca; tasks.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -20,10 +20,10 @@
     instances of the same libraries might exist, differing in version, build
     configuration, compiler, and MPI implementation. To manage these
     dependencies, you can use an environment module system. Most &hpca;
-    libraries provided with the &hpca; module for &sles; are built with support for environment
+    libraries provided with the &hpcm; for &sles; are built with support for environment
     modules. This chapter describes the environment module system
     <emphasis>Lmod</emphasis>, and a set of &hpca;
-    compute libraries shipped with the &hpca; module.
+    compute libraries shipped with the &hpcm;.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -40,7 +40,7 @@
    system environment for the use of a specific version. It supports
    hierarchical library dependencies and makes sure that the correct versions of
    dependent libraries are selected. Environment module-enabled library
-   packages supplied with the &hpca; module support parallel installation of
+   packages supplied with the &hpcm; support parallel installation of
    different versions and flavors of the same library or binary and are
    supplied with appropriate <literal>lmod</literal> module files.
   </para>
@@ -152,7 +152,7 @@
   <title>GNU Compiler Toolchain Collection for &hpca;</title>
 
   <para>
-   In the &hpca; module for &sles;, the GNU compiler collection version 7 is provided as the base
+   In the &hpcm; for &sles;, the GNU compiler collection version 7 is provided as the base
    compiler toolchain. The <package>gnu-compilers-hpc</package> package provides the
    environment module for the base version of the GNU compiler suite. This
    package must be installed when using any of the &hpca; libraries enabled for
@@ -276,7 +276,7 @@
   </para>
 
   <para>
-   The GNU compiler collection version 7 as provided with the &hpca; module
+   The GNU compiler collection version 7 as provided with the &hpcm;
    and the MPI flavors Open MPI v.3, Open MPI v.4, MPICH, and MVAPICH2 are
    currently supported.
   </para>
@@ -628,7 +628,7 @@
 
   <para>
    Three different implementation of the Message Passing Interface (MPI)
-   standard are provided standard with the &hpca; module:
+   standard are provided standard with the &hpcm;:
   </para>
 
   <itemizedlist>
@@ -776,7 +776,7 @@
   <title>Profiling and benchmarking libraries and tools</title>
 
   <para>
-   The &hpca; module for &sles; provides tools for profiling MPI applications and benchmarking
+   The &hpcm; for &sles; provides tools for profiling MPI applications and benchmarking
    MPI performance.
   </para>
 

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -16,7 +16,7 @@
  <info>
   <abstract>
    <para>
-    The &hpca; module for &sles; comes with preconfigured system roles. These
+    The &hpcm; for &sles; comes with preconfigured system roles. These
     roles provide a set of preselected packages typical for the specific role,
     and an installation workflow that configures the system to make
     the best use of system resources based on a typical use case for the role.
@@ -29,10 +29,10 @@
  </info>
 
   <sect1 xml:id="sec2-installation-systemrole">
-   <title>System roles for &sles; &hpca; module &productnumber;</title>
+   <title>System roles for &sles; &hpcm; &productnumber;</title>
    <para>
     You can choose specific roles for the system based on modules selected
-    during the installation process. When the &hpca; module is enabled,
+    during the installation process. When the &hpcm; is enabled,
     the following roles are available:
    </para>
    <variablelist>
@@ -159,16 +159,16 @@
     cluster. For more information, see <xref linkend="sec-remote-munge"/>.
    </para>
    <para>
-    The system roles are only available for new installations of the &hpca; module for &sles;.
+    The system roles are only available for new installations of the &hpcm; for &sles;.
    </para>
   </sect1>
   <sect1 xml:id="sec2-upgrade">
-   <title>Upgrading to &sles; &hpca; module &productnumber;</title>
+   <title>Upgrading to &sles; &hpcm; &productnumber;</title>
    <para>
-    In version 15 SP6, &slehpc; (&slehpca;) was removed as a separate product, and is now available as the &hpca; module for &sles; (&slsa;).
+    In version 15 SP6, &slehpc; (&slehpca;) was removed as a separate product, and is now available as the &hpcm; for &sles; (&slsa;).
    </para>
    <para>
-     You can upgrade from &slehpca; &prev-version; to &slsa; &productnumber; plus the &hpca; module.
+     You can upgrade from &slehpca; &prev-version; to &slsa; &productnumber; plus the &hpcm;.
    </para>
   </sect1>
 </chapter>

--- a/xml/introduction.xml
+++ b/xml/introduction.xml
@@ -16,7 +16,7 @@
  <info>
   <abstract>
    <para>
-    The &hpca; module for &sles; is a highly scalable, high-performance parallel computing platform
+    The &hpcm; for &sles; is a highly scalable, high-performance parallel computing platform
     for modeling, simulation, and advanced analytics workloads.
    </para>
   </abstract>
@@ -24,7 +24,7 @@
  <sect1 xml:id="sec-intro-provides">
   <title>Components provided</title>
   <para>
-   The &hpca; module for &sles; &productnumber; provides tools and libraries related to &hpc;.
+   The &hpcm; for &sles; &productnumber; provides tools and libraries related to &hpc;.
    This includes:
   </para>
   <itemizedlist>
@@ -100,14 +100,14 @@
  <sect1 xml:id="sec-introduction-hw">
   <title>Hardware platform support</title>
   <para>
-   The &hpca; module is available for &sles; &productnumber; on the
+   The &hpcm; is available for &sles; &productnumber; on the
    Intel 64/AMD64 (x86-64) and AArch64 platforms.
   </para>
  </sect1>
  <sect1 xml:id="sec-introduction-life">
   <title>Support and lifecycle</title>
   <para>
-   The &hpca; module is supported throughout the lifecycle of
+   The &hpcm; is supported throughout the lifecycle of
    &sles; &productnumber;, including the two lifecycle extensions, <emphasis>Extended Service
    Overlap Support</emphasis> (ESPOS) and <emphasis>Long Term Support
    Service</emphasis> (LTSS). Any released

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -2,14 +2,15 @@
 <!-- This file can be edited downstream. -->
 
 <!-- PRODUCT NAME AND VERSIONS -->
-<!ENTITY productname   "&slehpc;">
-<!ENTITY productnameshort "SLE-HPC">
+<!ENTITY productname   "&sles;">
+<!ENTITY productnameshort "&slsa;">
 <!ENTITY productnumber "&product-ga; SP&product-sp;">
 <!ENTITY productnumbershort "&product-ga;.&product-sp;">
 
 <!ENTITY hpc "High Performance Computing">
 <!ENTITY hpca "HPC">
 <!ENTITY slehpca "&slea; &hpca;">
+<!ENTITY hpcm "HPC module">
 
 <!ENTITY product-ga    "15">
 <!ENTITY product-sp    "6">

--- a/xml/remote_administration.xml
+++ b/xml/remote_administration.xml
@@ -132,7 +132,7 @@ nodenames[A-B]          attr[=value],attr[=value],...</screen>
    <command>zypper in pdsh</command>.
   </para>
   <para>
-   The &hpca; module for &sles; supports the back-ends <literal>ssh</literal>,
+   The &hpcm; for &sles; supports the back-ends <literal>ssh</literal>,
    <literal>&mrsh;</literal>, and <literal>exec</literal>. The
    <literal>ssh</literal> back-end is the default. Non-default login methods
    can be used by setting the <literal>PDSH_RCMD_TYPE</literal>


### PR DESCRIPTION
### Description

Here's the agreed-upon title change for SP6. I also added an entity for "HPC module" so I don't have to keep typing it. I also-also updated the guide's abstract so that it has a bit more context when people get to it from the SLES page.

### Are there any relevant issues/feature requests?

* jsc#PED-7683

### Which product versions do the changes apply to?

- [x] SLE HPC 15 next *(current `main`, no backport necessary)*
- [ ] SLE HPC 15 SP5
- [ ] SLE HPC 15 SP4
- [ ] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
