### PR TITLE
Remove system roles for 15 SP6

### DIFF
--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -16,10 +16,7 @@
  <info>
   <abstract>
    <para>
-    The &hpcm; for &sles; comes with preconfigured system roles. These
-    roles provide a set of preselected packages typical for the specific role,
-    and an installation workflow that configures the system to make
-    the best use of system resources based on a typical use case for the role.
+    This chapter contains basic information about installing and upgrading the &hpcm; for &sles;.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -29,143 +26,31 @@
  </info>
 
   <sect1 xml:id="sec2-installation-systemrole">
-   <title>System roles for &sles; &hpcm; &productnumber;</title>
+   <title>Installing &sles; &hpcm; &productnumber;</title>
    <para>
-    You can choose specific roles for the system based on modules selected
-    during the installation process. When the &hpcm; is enabled,
-    the following roles are available:
+    In addition to the default &sles; modules, make sure the following modules are also enabled:
    </para>
-   <variablelist>
-    <varlistentry>
-     <term>&hpca; management server (head node)</term>
-     <listitem>
-      <para>
-       This role includes the following features:
-      </para>
-      <itemizedlist>
-       <listitem>
-        <para>
-         Uses Btrfs as the default root file system
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Includes &hpca;-enabled libraries
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Disables the firewall and Kdump services
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Installs a controller for the &slurm; workload manager
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Mounts a large scratch partition to <filename>/var/tmp</filename>
-        </para>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>&hpca; compute node</term>
-     <listitem>
-      <para>
-       This role includes the following features:
-      </para>
-      <itemizedlist>
-       <listitem>
-        <para>
-         Based on the minimal setup configuration
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Uses XFS as the default root file system
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Includes &hpca;-enabled libraries
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Disables firewall and Kdump services
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Installs a client for the &slurm; workload manager
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Does not create a separate <literal>/home</literal> partition
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Mounts a large scratch partition to <filename>/var/tmp</filename>
-        </para>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>&hpca; development node</term>
-     <listitem>
-      <para>
-       This role includes the following features:
-      </para>
-      <itemizedlist>
-       <listitem>
-        <para>
-         Includes &hpca;-enabled libraries
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Adds compilers and development toolchains
-        </para>
-       </listitem>
-      </itemizedlist>
-     </listitem>
-    </varlistentry>
-   </variablelist>
+   <itemizedlist>
+    <listitem>
+     <para>
+      <literal>Development Tools Module</literal>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <literal>HPC Module</literal>
+     </para>
+    </listitem>
+   </itemizedlist>
    <para>
-    The scratch partition <literal>/var/tmp/</literal> is only created if
-    there is sufficient space available on the installation medium (minimum
-    32&nbsp;GB).
-   </para>
-   <para>
-    The environment module <literal>Lmod</literal> is installed for all
-    roles. It is required at build time and runtime of the system. For more
-    information, see <xref linkend="sec-compute-lmod"/>.
-   </para>
-   <para>
-    All libraries specifically built for &hpca; are installed under
-    <literal>/usr/lib/hpc</literal>. They are not part of the standard search
-    path, so the <literal>Lmod</literal> environment module system is
-    required.
-   </para>
-   <para>
-    <literal>&munge;</literal> authentication is installed for all roles. &munge;
-    keys are generated and must be copied to all nodes in the
-    cluster. For more information, see <xref linkend="sec-remote-munge"/>.
-   </para>
-   <para>
-    The system roles are only available for new installations of the &hpcm; for &sles;.
+    Use either the <literal>Text Mode</literal> or <literal>Minimal</literal> system role.
    </para>
   </sect1>
   <sect1 xml:id="sec2-upgrade">
    <title>Upgrading to &sles; &hpcm; &productnumber;</title>
    <para>
-    In version 15 SP6, &slehpc; (&slehpca;) was removed as a separate product, and is now available as the &hpcm; for &sles; (&slsa;).
+    In version 15 SP6, &slehpc; (&slehpca;) was removed as a separate product, and is
+    now available as the &hpcm; for &sles; (&slsa;).
    </para>
    <para>
      You can upgrade from &slehpca; &prev-version; to &slsa; &productnumber; plus the &hpcm;.

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -16,7 +16,9 @@
  <info>
   <abstract>
    <para>
-    This chapter contains basic information about installing and upgrading the &hpcm; for &sles;.
+    In version 15 SP6, &slehpc; (&slehpca;) was removed as a separate product. The &hpcm; is
+    now available with &sles; (&slsa;). This chapter contains basic information about installing
+    &slsa; for &hpca; use cases, and upgrading from &slehpca; to &slsa;.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -26,7 +28,7 @@
  </info>
 
   <sect1 xml:id="sec2-installation-systemrole">
-   <title>Installing &sles; &hpcm; &productnumber;</title>
+   <title>Installing &sles; &productnumber; for &hpca;</title>
    <para>
     In addition to the default &sles; modules, make sure the following modules are also enabled:
    </para>
@@ -43,17 +45,21 @@
     </listitem>
    </itemizedlist>
    <para>
-    Use either the <literal>Text Mode</literal> or <literal>Minimal</literal> system role.
+    In &hpc;, systems take on different roles and individual installations vary widely. Therefore,
+    &suse; does not provide predefined system roles with the &hpcm;. We recommend using either the
+    <literal>Text Mode</literal> or <literal>Minimal</literal> system role and adding components
+    according to your needs.
    </para>
   </sect1>
   <sect1 xml:id="sec2-upgrade">
-   <title>Upgrading to &sles; &hpcm; &productnumber;</title>
+   <title>Upgrading from &slehpca; to &sles;</title>
    <para>
-    In version 15 SP6, &slehpc; (&slehpca;) was removed as a separate product, and is
-    now available as the &hpcm; for &sles; (&slsa;).
+    In version 15 SP6, the &slehpca; product was removed. The &hpcm; is now available with &sles;.
    </para>
    <para>
-     You can upgrade from &slehpca; &prev-version; to &slsa; &productnumber; plus the &hpcm;.
+     You can migrate to &slsa; &productnumber; when upgrading from &slehpca; 15 SP5. This migration
+     retains all the software modules and packages that were enabled on &slehpca;. After the
+     migration, the same software selection will be available as on &slehpca;.
    </para>
   </sect1>
 </chapter>

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -17,8 +17,8 @@
   <abstract>
    <para>
     In version 15 SP6, &slehpc; (&slehpca;) was removed as a separate product. The &hpcm; is
-    now available with &sles; (&slsa;). This chapter contains basic information about installing
-    &slsa; for &hpca; use cases, and upgrading from &slehpca; to &slsa;.
+    now available with &sles; (&slsa;). This chapter contains information about installing &slsa;
+    for &hpca; use cases, and upgrading to &slsa; 15 SP6 from &slehpca; 15 SP5, SP4, or SP3.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -45,10 +45,43 @@
     </listitem>
    </itemizedlist>
    <para>
+    Selecting these modules during installation ensures that all required modules and
+    their dependencies are enabled.
+   </para>
+   <note>
+     <title>Enabling modules after installation</title>
+     <para>
+       If you need to enable these modules with <command>SUSEConnect</command> after installing
+       &slsa;, you must enable them individually and in the following order:
+     </para>
+     <orderedlist>
+       <listitem>
+         <para>
+           <literal>Desktop Applications Module</literal>
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           <literal>Development Tools Module</literal>
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           <literal>Web and Scripting Module</literal>
+         </para>
+       </listitem>
+       <listitem>
+         <para>
+           <literal>HPC Module</literal>
+         </para>
+       </listitem>
+     </orderedlist>
+   </note>
+   <para>
     In &hpc;, systems take on different roles and individual installations vary widely. Therefore,
-    &suse; does not provide predefined system roles with the &hpcm;. We recommend using either the
-    <literal>Text Mode</literal> or <literal>Minimal</literal> system role and adding components
-    according to your needs.
+    from 15 SP6 onwards &suse; no longer provides predefined system roles with the &hpcm;.
+    We recommend using either the <literal>Text Mode</literal> or <literal>Minimal</literal>
+    system role and adding components according to your needs.
    </para>
   </sect1>
   <sect1 xml:id="sec2-upgrade">
@@ -57,9 +90,9 @@
     In version 15 SP6, the &slehpca; product was removed. The &hpcm; is now available with &sles;.
    </para>
    <para>
-     You can migrate to &slsa; &productnumber; when upgrading from &slehpca; 15 SP5. This migration
-     retains all the software modules and packages that were enabled on &slehpca;. After the
-     migration, the same software selection will be available as on &slehpca;.
+     Upgrading to 15 SP6 from &slehpca; 15 SP5, SP4, or SP3 migrates the system to &sles;.
+     This migration retains all the software modules and packages that were enabled on &slehpca;.
+     After the migration, the same software selection will be available as on &slehpca;.
    </para>
   </sect1>
 </chapter>

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -87,7 +87,7 @@
   <sect1 xml:id="sec2-upgrade">
    <title>Upgrading from &slehpca; to &sles;</title>
    <para>
-    In version 15 SP6, the &slehpca; product was removed. The &hpcm; is now available with &sles;.
+    With the removal of the &slehpca; product in 15 SP6, the &hpcm; is now available with &sles;.
    </para>
    <para>
      Upgrading to 15 SP6 from &slehpca; 15 SP5, SP4, or SP3 migrates the system to &sles;.

--- a/xml/installation.xml
+++ b/xml/installation.xml
@@ -18,7 +18,7 @@
    <para>
     In version 15 SP6, &slehpc; (&slehpca;) was removed as a separate product. The &hpcm; is
     now available with &sles; (&slsa;). This chapter contains information about installing &slsa;
-    for &hpca; use cases, and upgrading to &slsa; 15 SP6 from &slehpca; 15 SP5, SP4, or SP3.
+    for &hpca; use cases, and upgrading to &slsa; 15 SP6 from &slehpca; 15 SP5, SP4 or SP3.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -78,8 +78,8 @@
      </orderedlist>
    </note>
    <para>
-    In &hpc;, systems take on different roles and individual installations vary widely. Therefore,
-    from 15 SP6 onwards &suse; no longer provides predefined system roles with the &hpcm;.
+    In &hpc;, systems take on different roles, and individual installations vary widely. Therefore,
+    from 15 SP6 onwards, &suse; no longer provides predefined system roles with the &hpcm;.
     We recommend using either the <literal>Text Mode</literal> or <literal>Minimal</literal>
     system role and adding components according to your needs.
    </para>
@@ -90,7 +90,7 @@
     With the removal of the &slehpca; product in 15 SP6, the &hpcm; is now available with &sles;.
    </para>
    <para>
-     Upgrading to 15 SP6 from &slehpca; 15 SP5, SP4, or SP3 migrates the system to &sles;.
+     Upgrading to 15 SP6 from &slehpca; 15 SP5, SP4 or SP3 migrates the system to &sles;.
      This migration retains all the software modules and packages that were enabled on &slehpca;.
      After the migration, the same software selection will be available as on &slehpca;.
    </para>


### PR DESCRIPTION
### Description

@e4t I've removed the system roles and replaced them with the required modules and recommended roles.
This is extremely minimal for now, but should be replaced with a proper installation quickstart (DOCTEAM-520). 
I also want to expand the upgrade content (DOCTEAM-521).

### Are there any relevant issues/feature requests?

* jsc#PED-7683
* jsc#PED-8199

### Which product versions do the changes apply to?

- [x] SLE HPC 15 next *(current `main`, no backport necessary)*
- [ ] SLE HPC 15 SP5
- [ ] SLE HPC 15 SP4
- [ ] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
