### PR TITLE
Explain how to find out new slurm version

### DIFF
--- a/xml/slurm.xml
+++ b/xml/slurm.xml
@@ -938,8 +938,10 @@ Description="subgroup" Organization=bavaria</screen>
     Upgrade packages (that is, packages that were not initially supplied with
     the module or service pack) have their major version encoded in the package
     name (with periods <literal>.</literal> replaced by underscores
-    <literal>_</literal>). For example, for version 18.08, this would be
-    <literal>slurm_18_08-*.rpm</literal>.
+    <literal>_</literal>). For example, for version 23.02, this would be
+    <literal>slurm_23_02-*.rpm</literal>. To find out the latest version of &slurm;,
+    you can check <menuchoice><guimenu>My Tools</guimenu><guimenu>Packages</guimenu></menuchoice>
+    in the &scc;, or run <command>zypper search -v slurm</command> on a node.
    </para>
    <para>
     With each version, configuration options for


### PR DESCRIPTION
### Description

Fix for Issue #45 

### Are there any relevant issues/feature requests?

* jsc#DOCTEAM-1247

### Which product versions do the changes apply to?

- [x] SLE HPC 15 next *(current `main`, no backport necessary)*
- [x] SLE HPC 15 SP6
- [x] SLE HPC 15 SP5
- [x] SLE HPC 15 SP4
- [x] SLE HPC 15 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
