### PR TITLE
Revision History: initial entry for FCS of 15 SP7 

### DIFF
--- a/xml/MAIN.hpc-guide.xml
+++ b/xml/MAIN.hpc-guide.xml
@@ -38,7 +38,7 @@
   </meta>
   <revhistory xml:id="rh-book-hpc">
     <revision>
-     <date>2024-06-24</date>
+     <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.


### PR DESCRIPTION
### Description

Set date in revision history to FCS date for 15 SP7 and keep initial entry as agreed with @lvicoun.

### Which product versions do the changes apply to?

- [x] SLE HPC 15 next *(current `main`, no backport necessary)*

