### PR TITLE
Remove line about package hub

### DIFF
--- a/xml/compute.xml
+++ b/xml/compute.xml
@@ -28,7 +28,7 @@
   </dm:docmanager>
  <revhistory xml:id="rh-cha-compute">
    <revision>
-     <date>2024-03-12</date>
+     <date>2026-04-21</date>
      <revdescription>
        <para/>
      </revdescription>

--- a/xml/environment-containers.xml
+++ b/xml/environment-containers.xml
@@ -8,7 +8,7 @@
     %entities;
 ]>
 
-<!-- trichardson 2023-09-07: Stub for now; can be expanded if apptainer is added to SLE later -->
+<!-- trichardson 2026-04-21: Stub for now; task to expand it is PED-7125 -->
 
 <sect1 xml:id="sec-environment-containers" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.1"
@@ -27,18 +27,13 @@
     <emphasis>environment containers</emphasis>. Environment containers include only the
     components that are part of the environment, plus any required user applications.
     To create a container from the current &hpca; environment, use the container platform
-    &apptainer; (formerly called Singularity). &apptainer; is available from &ph;.
-    You can also use &spack; to configure the environment to use with &apptainer;.
+    &apptainer; (formerly called Singularity). You can also use &spack; to configure the
+    environment to use with &apptainer;.
   </para>
   <para>
     For more information, see the following documentation:
   </para>
   <itemizedlist>
-    <listitem>
-      <para>
-        Enabling the &ph; extension: <link xlink:href="https://packagehub.suse.com/how-to-use/"/>.
-      </para>
-    </listitem>
     <listitem>
       <para>
         Using &spack; to configure the environment:


### PR DESCRIPTION
### Description

Apptainer is in the HPC module in 15 SP6 and SP7.

### Are there any relevant issues/feature requests?

* bsc#1262172
* jsc#DOCTEAM-2249

### Which product versions do the changes apply to?

- [x] SLE HPC 15 SP7 *(current `main`, no backport necessary)*
- [x] SLE HPC 15 SP6
- [ ] SLE HPC 15 SP5
- [ ] SLE HPC 15 SP4
- [ ] SLE HPC 15 SP3

### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] all necessary backports are done
- [ ] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 

